### PR TITLE
✨Listing.get by address

### DIFF
--- a/contracts/contracts/Listing.sol
+++ b/contracts/contracts/Listing.sol
@@ -28,6 +28,7 @@ contract Listing {
     bytes32 public ipfsHash;
     uint public price;
     uint public unitsAvailable;
+    uint public created;
     uint public expiration;
     Purchase[] public purchases;
 
@@ -45,7 +46,8 @@ contract Listing {
       ipfsHash = _ipfsHash;
       price = _price;
       unitsAvailable = _unitsAvailable;
-      expiration = now + 60 days;
+      created = now;
+      expiration = created + 60 days;
     }
 
   /*
@@ -64,9 +66,9 @@ contract Listing {
   function data()
     public
     view
-    returns (address _owner, bytes32 _ipfsHash, uint _price, uint _unitsAvailable, uint _expiration)
+    returns (address _owner, bytes32 _ipfsHash, uint _price, uint _unitsAvailable, uint _created, uint _expiration)
   {
-    return (owner, ipfsHash, price, unitsAvailable, expiration);
+    return (owner, ipfsHash, price, unitsAvailable, created, expiration);
   }
 
   /// @dev buyListing(): Buy a listing

--- a/contracts/contracts/Listing.sol
+++ b/contracts/contracts/Listing.sol
@@ -61,6 +61,13 @@ contract Listing {
     * Public functions
     */
 
+  function data()
+    public
+    view
+    returns (address _owner, bytes32 _ipfsHash, uint _price, uint _unitsAvailable, uint _expiration)
+  {
+    return (owner, ipfsHash, price, unitsAvailable, expiration);
+  }
 
   /// @dev buyListing(): Buy a listing
   /// @param _unitsToBuy Number of units to buy

--- a/contracts/test/TestListing.js
+++ b/contracts/test/TestListing.js
@@ -51,7 +51,8 @@ contract("Listing", accounts => {
     assert.equal(data[1], ipfsHash, "ipfsHash")
     assert.equal(data[2], price, "price")
     assert.equal(data[3], unitsAvailable, "unitsAvailable")
-    assert.equal(data[4].toNumber(), (await listing.expiration()).toNumber() , "expiration")
+    assert.equal(data[4].toNumber(), (await listing.created()).toNumber() , "created")
+    assert.equal(data[5].toNumber(), (await listing.expiration()).toNumber() , "expiration")
   })
 
   it("should decrement the number of units sold", async function() {

--- a/contracts/test/TestListing.js
+++ b/contracts/test/TestListing.js
@@ -45,6 +45,15 @@ contract("Listing", accounts => {
     assert.equal(newPrice, price, "price is correct")
   })
 
+  it("should allow getting listing information", async function() {
+    let data = await listing.data()
+    assert.equal(data[0], seller, "owner")
+    assert.equal(data[1], ipfsHash, "ipfsHash")
+    assert.equal(data[2], price, "price")
+    assert.equal(data[3], unitsAvailable, "unitsAvailable")
+    assert.equal(data[4].toNumber(), (await listing.expiration()).toNumber() , "expiration")
+  })
+
   it("should decrement the number of units sold", async function() {
     const unitsToBuy = 3
     await listing.buyListing(unitsToBuy, { from: buyer, value: 6 })

--- a/src/resources/listings.js
+++ b/src/resources/listings.js
@@ -12,13 +12,34 @@ class Listings extends ResourceBase{
     return await this.contractService.getAllListingIds()
   }
 
+  async get(address) {
+    const contractData = await this.contractFn(address, "data")
+    let ipfsHash = this.contractService.getIpfsHashFromBytes32(contractData[1])
+    const ipfsData = await this.ipfsService.getFile(ipfsHash)
+
+    let listing = {
+      address: address,
+      ipfsHash: ipfsHash,
+      sellerAddress: contractData[0],
+      priceWei: contractData[2],
+      price: this.contractService.web3.fromWei(contractData[2], "ether").toNumber(),
+      unitsAvailable: contractData[3],
+      expiration: contractData[4].toNumber(),
+
+      name: ipfsData.data.name,
+      category: ipfsData.data.category,
+      description: ipfsData.data.description,
+      location: ipfsData.data.location,
+      pictures: ipfsData.data.pictures
+    }
+
+    return listing
+  }
+
+  // This method is DEPRCIATED
   async getByIndex(listingIndex) {
-    const contractData = await this.contractService.getListing(
-      listingIndex
-    )
-    const ipfsData = await this.ipfsService.getFile(
-      contractData.ipfsHash
-    )
+    const contractData = await this.contractService.getListing(listingIndex)
+    const ipfsData = await this.ipfsService.getFile(contractData.ipfsHash)
     // ipfsService should have already checked the contents match the hash,
     // and that the signature validates
 

--- a/src/resources/listings.js
+++ b/src/resources/listings.js
@@ -21,7 +21,7 @@ class Listings extends ResourceBase{
       address: address,
       ipfsHash: ipfsHash,
       sellerAddress: contractData[0],
-      priceWei: contractData[2],
+      priceWei: contractData[2].toString(),
       price: this.contractService.web3.fromWei(contractData[2], "ether").toNumber(),
       unitsAvailable: contractData[3].toNumber(),
       created: contractData[4].toNumber(),

--- a/src/resources/listings.js
+++ b/src/resources/listings.js
@@ -23,7 +23,7 @@ class Listings extends ResourceBase{
       sellerAddress: contractData[0],
       priceWei: contractData[2],
       price: this.contractService.web3.fromWei(contractData[2], "ether").toNumber(),
-      unitsAvailable: contractData[3],
+      unitsAvailable: contractData[3].toNumber(),
       created: contractData[4].toNumber(),
       expiration: contractData[5].toNumber(),
 

--- a/src/resources/listings.js
+++ b/src/resources/listings.js
@@ -24,7 +24,8 @@ class Listings extends ResourceBase{
       priceWei: contractData[2],
       price: this.contractService.web3.fromWei(contractData[2], "ether").toNumber(),
       unitsAvailable: contractData[3],
-      expiration: contractData[4].toNumber(),
+      created: contractData[4].toNumber(),
+      expiration: contractData[5].toNumber(),
 
       name: ipfsData.data.name,
       category: ipfsData.data.category,

--- a/test/resource_listings.test.js
+++ b/test/resource_listings.test.js
@@ -43,10 +43,12 @@ describe("Listing Resource", function() {
     expect(listing.index).to.equal(listingIds.length - 1)
   })
 
-  it("should get a listing by hash", async () => {
+  it("should get a listing by address", async () => {
     await listings.create({ name: "Foo Bar", price: 1 }, "")
     let listingIds = await contractService.getAllListingIds()
-    const listingFromIndex = await listings.getByIndex(listingIds[listingIds.length - 1])
+    const listingFromIndex = await listings.getByIndex(
+      listingIds[listingIds.length - 1]
+    )
     const listing = await listings.get(listingFromIndex.address)
     expect(listing.name).to.equal("Foo Bar")
   })

--- a/test/resource_listings.test.js
+++ b/test/resource_listings.test.js
@@ -35,12 +35,20 @@ describe("Listing Resource", function() {
     expect(ids.length).to.be.greaterThan(1)
   })
 
-  it("should get a listing", async () => {
+  it("should get a listing by index", async () => {
     await listings.create({ name: "Foo Bar", price: 1 }, "")
     let listingIds = await contractService.getAllListingIds()
     const listing = await listings.getByIndex(listingIds[listingIds.length - 1])
     expect(listing.name).to.equal("Foo Bar")
     expect(listing.index).to.equal(listingIds.length - 1)
+  })
+
+  it("should get a listing by hash", async () => {
+    await listings.create({ name: "Foo Bar", price: 1 }, "")
+    let listingIds = await contractService.getAllListingIds()
+    const listingFromIndex = await listings.getByIndex(listingIds[listingIds.length - 1])
+    const listing = await listings.get(listingFromIndex.address)
+    expect(listing.name).to.equal("Foo Bar")
   })
 
   it("should buy a listing", async () => {


### PR DESCRIPTION
### Description:

Currently we only can get information about listing by the index number of where its address is stored in the ListingsRegistry contract. This is a left over of when when we used store all listing data in the ListingsRegistry contract.

We need to allow API users to directly get the Listing data from a listing contract address. This is a much more useful way of getting the listing, and will be the primary way listings are fetched in the future.

This adds an API method `origin.listings.get(listingAddress)`, and the need contract changes to use it.

It also adds a listing created date to the listing, since this is information we'll need to use from listings on the front end.

This should merged in after PR #111.

### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [x] Submit to the `develop` branch instead of `master`

Will do later tonight:
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs) 
