### PR TITLE
🔧 Contract test improvements

### DIFF
--- a/scripts/test-contracts.js
+++ b/scripts/test-contracts.js
@@ -27,7 +27,7 @@ const start = async () => {
   runTests()
 
   // watch contracts
-  watch('./contracts/contracts', { recursive: true }, async (evt, name) => {
+  watch(['./contracts/contracts', './contracts/test'], { recursive: true }, async (evt, name) => {
     console.log('%s changed.', name)
     runTests()
   })

--- a/scripts/test-contracts.js
+++ b/scripts/test-contracts.js
@@ -1,5 +1,6 @@
 const startGanache = require('./helpers/start-ganache')
 const testContracts = require('./helpers/test-contracts')
+const buildContracts = require('./helpers/build-contracts')
 const watch = require('node-watch')
 
 // Simple enqueueing system to prevent interrupting a test. Rerunning in the middle of a test causes issues.
@@ -8,6 +9,7 @@ let isEnqueued = false
 const runTests = async () => {
   if (!isRunning) {
     isRunning = true
+    await buildContracts()
     await testContracts()
     isRunning = false
     if (isEnqueued) {


### PR DESCRIPTION
- Contracts tests were not rebuilding contracts before launching tests
- Add watching contract test files in addition to contracts