### PR TITLE
Metamask's gas estimates/defaults are sometimes too low.

### DIFF
--- a/src/ResourceBase.js
+++ b/src/ResourceBase.js
@@ -25,6 +25,7 @@ class ResourceBase {
     // Setup options
     const opts = Object.assign(options, {}) // clone options
     opts.from = await this.contractService.currentAccount()
+    opts.gas = options.gas || 50000 // Default gas
     // Get contract and run trasaction
     const contractDefinition = this.contractDefinition
     const contract = await contractDefinition.at(address)

--- a/src/resources/purchases.js
+++ b/src/resources/purchases.js
@@ -40,7 +40,7 @@ class Purchases extends ResourceBase{
   }
 
   async sellerConfirmShipped(address) {
-    return await this.contractFn(address, "sellerConfirmShipped")
+    return await this.contractFn(address, "sellerConfirmShipped",[], {gas: 80000})
   }
 
   async buyerConfirmReceipt(address) {


### PR DESCRIPTION
Metamask and web3's default gas sent values change from release to release. What worked before can be too low later.

We'll set a default gas amount of 50,000 for origin.js transactions. (This is about 10 cents USD at current gas prices.)

As before, and individual origin.js API contract transactions can set their own gas amounts to be sent.

First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)
- [x] Submit to the `develop` branch instead of `master`