### PR TITLE
Timestamps should really be returned as plain numbers

### DIFF
--- a/src/resources/purchases.js
+++ b/src/resources/purchases.js
@@ -30,8 +30,8 @@ class Purchases extends ResourceBase{
       stage: _NUMBERS_TO_STAGE[contractData[0]],
       listingAddress: contractData[1],
       buyerAddress: contractData[2],
-      created: contractData[3],
-      buyerTimout: contractData[4]
+      created: contractData[3].toNumber(),
+      buyerTimout: contractData[4].toNumber()
     }
   }
 


### PR DESCRIPTION
Timestamps should really be returned as plain numbers, rather than BigNumbers.

- This is consistent with our other code get - I just missed the conversion here.
- Docs are already updated to use this.
- BigNumbers break our habit of returning only plain json strings/numbers/arrays/objects.
- Plain javascript ints used a timestamps go up to the year 2255.

### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)
- [x] Submit to the `develop` branch instead of `master`
