### PR TITLE
Improvements to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,22 +77,24 @@ And buyers to:
 
  ### Local
 
+1. Fork the repo on GitHub
+
 1. Clone
-```
-git clone https://github.com/OriginProtocol/platform origin-platform && cd origin-platform
-```
+    ```
+    git clone git@github.com:YOUR_GITHUB_USERNAME/origin-js.git && cd origin-js
+    ```
 
-2. Setup (shortcut for `npm install && npm link`). Linking makes this available as a local npm package for local dapp development.
- ```
- npm run setup
- ```
+1. Setup (shortcut for `npm install && npm link`). Linking makes this available as a local npm package for local dapp development.
+    ```
+    npm run setup
+    ```
 
-3. Start the localblockchain and create the build. Code changes will trigger a live rebuild.
- ```
- npm start
- ```
+1. Start the localblockchain and create the build. Code changes will trigger a live rebuild.
+    ```
+    npm start
+    ```
 
- 4. To develop against a working dapp and UI, see [the instructions in our demo dapp](https://github.com/OriginProtocol/demo-dapp#developing-with-a-local-chain).
+1. To develop against a working dapp and UI, see [the instructions in our demo dapp](https://github.com/OriginProtocol/demo-dapp#developing-with-a-local-chain).
 
  ## Import
 


### PR DESCRIPTION
### Description

* Start with step for Forking the repo, since that will be required for
all contributors without write access to the repo.

* Add correct URL for git cloning instructions (repo was renamed but
that name in the README did not change)

* Suggest cloning with SSH instead of HTTPS since that is how most
people access GitHub repos, in my experience (could be wrong on this
one).

* Use `1` for all items in ordered list so that they do not need to be
renamed if items are added. GitHub markdown will automatically increment
numbers in ordered lists.
