### PR TITLE
Listings.purchasesLength now returns a plain number

### DIFF
--- a/src/resources/listings.js
+++ b/src/resources/listings.js
@@ -121,7 +121,7 @@ class Listings extends ResourceBase{
   }
 
   async purchasesLength(address) {
-    return await this.contractFn(address, "purchasesLength")
+    return (await this.contractFn(address, "purchasesLength")).toNumber()
   }
 
   async purchaseAddressByIndex(address, index) {

--- a/test/resource_listings.test.js
+++ b/test/resource_listings.test.js
@@ -107,7 +107,7 @@ describe("Listing Resource", function() {
 
     it("should get the number of purchases", async () => {
       const numPurchases = await listings.purchasesLength(listing.address)
-      expect(numPurchases.toNumber()).to.equal(1)
+      expect(numPurchases).to.equal(1)
     })
 
     it("should get the address of a purchase", async () => {


### PR DESCRIPTION
Listings.purchasesLength doesn't need to be BigNumbers. We really want to keep the API returning plain javascript objects that can be serialized into JSON. I let this one slip by somehow.

### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)
- [x] Submit to the `develop` branch instead of `master`
