### PR TITLE
🔧 Use our own web3 instance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2767,6 +2767,22 @@
         "sha.js": "2.4.8"
       }
     },
+    "cross-fetch": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.1.1.tgz",
+      "integrity": "sha512-3W94GTFVrSQWw/xHsLpX+z3ArhDKjoh7pJfl4+5sbch0V17ZfPjhZ+gnUdz56t7eoFXI9DhdJtaZTr7jmPL2EQ==",
+      "requires": {
+        "node-fetch": "2.1.2",
+        "whatwg-fetch": "2.0.4"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+        }
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -4063,13 +4079,13 @@
       "dev": true,
       "requires": {
         "bn.js": "4.11.7",
-        "ethereumjs-util": "5.1.5"
+        "ethereumjs-util": "5.2.0"
       },
       "dependencies": {
         "ethereumjs-util": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.5.tgz",
-          "integrity": "sha512-xPaSEATYJpMTCGowIt0oMZwFP4R1bxd6QsWgkcDvFL0JtXsr39p32WEcD14RscCjfP41YXZPCVWA4yAg0nrJmw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
           "dev": true,
           "requires": {
             "bn.js": "4.11.7",
@@ -4800,13 +4816,15 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
           "dev": true,
           "optional": true
         },
         "ajv": {
           "version": "4.11.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4816,18 +4834,21 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4837,42 +4858,49 @@
         },
         "asn1": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
           "dev": true,
           "optional": true
         },
         "assert-plus": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
           "dev": true,
           "optional": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
           "dev": true,
           "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
           "dev": true,
           "optional": true
         },
         "aws4": {
           "version": "1.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
           "dev": true,
           "optional": true
         },
         "balanced-match": {
           "version": "0.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4881,7 +4909,8 @@
         },
         "block-stream": {
           "version": "0.0.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "dev": true,
           "requires": {
             "inherits": "2.0.3"
@@ -4889,7 +4918,8 @@
         },
         "boom": {
           "version": "2.10.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
             "hoek": "2.16.3"
@@ -4897,7 +4927,8 @@
         },
         "brace-expansion": {
           "version": "1.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
           "dev": true,
           "requires": {
             "balanced-match": "0.4.2",
@@ -4906,29 +4937,34 @@
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
           "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "dev": true,
           "optional": true
         },
         "co": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true,
           "requires": {
             "delayed-stream": "1.0.0"
@@ -4936,22 +4972,26 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4960,7 +5000,8 @@
         },
         "dashdash": {
           "version": "1.14.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4969,7 +5010,8 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -4977,7 +5019,8 @@
         },
         "debug": {
           "version": "2.6.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4986,24 +5029,28 @@
         },
         "deep-extend": {
           "version": "0.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
           "dev": true,
           "optional": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5012,24 +5059,28 @@
         },
         "extend": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
           "dev": true,
           "optional": true
         },
         "extsprintf": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
           "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
           "dev": true,
           "optional": true
         },
         "form-data": {
           "version": "2.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5040,12 +5091,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "fstream": {
           "version": "1.0.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -5056,7 +5109,8 @@
         },
         "fstream-ignore": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5067,7 +5121,8 @@
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5083,7 +5138,8 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5092,7 +5148,8 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -5100,7 +5157,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -5113,18 +5171,21 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
           "dev": true,
           "optional": true
         },
         "har-validator": {
           "version": "4.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5134,13 +5195,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "hawk": {
           "version": "3.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5152,12 +5215,14 @@
         },
         "hoek": {
           "version": "2.16.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
           "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5168,7 +5233,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
             "once": "1.4.0",
@@ -5177,18 +5243,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
@@ -5196,24 +5265,28 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
           "dev": true,
           "optional": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
           "dev": true,
           "optional": true
         },
         "jodid25519": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5222,19 +5295,22 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "dev": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
           "dev": true,
           "optional": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5243,19 +5319,22 @@
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
           "dev": true,
           "optional": true
         },
         "jsonify": {
           "version": "0.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
           "dev": true,
           "optional": true
         },
         "jsprim": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5267,7 +5346,8 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -5275,12 +5355,14 @@
         },
         "mime-db": {
           "version": "1.27.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
           "dev": true
         },
         "mime-types": {
           "version": "2.1.15",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
           "dev": true,
           "requires": {
             "mime-db": "1.27.0"
@@ -5288,7 +5370,8 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.7"
@@ -5296,12 +5379,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -5309,13 +5394,15 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "node-pre-gyp": {
           "version": "0.6.36",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
+          "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5332,7 +5419,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5342,7 +5430,8 @@
         },
         "npmlog": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5354,24 +5443,28 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -5379,19 +5472,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5401,35 +5497,41 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "performance-now": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
           "dev": true
         },
         "punycode": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true,
           "optional": true
         },
         "qs": {
           "version": "6.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5441,7 +5543,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -5449,7 +5552,8 @@
         },
         "readable-stream": {
           "version": "2.2.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
           "dev": true,
           "requires": {
             "buffer-shims": "1.0.0",
@@ -5463,7 +5567,8 @@
         },
         "request": {
           "version": "2.81.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5493,7 +5598,8 @@
         },
         "rimraf": {
           "version": "2.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
           "dev": true,
           "requires": {
             "glob": "7.1.2"
@@ -5501,30 +5607,35 @@
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "sntp": {
           "version": "1.0.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5533,7 +5644,8 @@
         },
         "sshpk": {
           "version": "1.13.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5550,7 +5662,8 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -5558,7 +5671,8 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "1.1.0",
@@ -5568,7 +5682,8 @@
         },
         "string_decoder": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.0.1"
@@ -5576,13 +5691,15 @@
         },
         "stringstream": {
           "version": "0.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
           "dev": true,
           "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
@@ -5590,13 +5707,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "2.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
           "requires": {
             "block-stream": "0.0.9",
@@ -5606,7 +5725,8 @@
         },
         "tar-pack": {
           "version": "3.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5622,7 +5742,8 @@
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5631,7 +5752,8 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5640,30 +5762,35 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "dev": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "dev": true,
           "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true
         },
         "uuid": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
           "dev": true,
           "optional": true
         },
         "verror": {
           "version": "1.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5672,7 +5799,8 @@
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5681,7 +5809,8 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         }
       }
@@ -6324,24 +6453,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
+          "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6351,30 +6484,35 @@
         },
         "asn1": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
           "dev": true,
           "optional": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
           "dev": true,
           "optional": true
         },
         "aws4": {
           "version": "1.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
           "dev": true,
           "optional": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6383,7 +6521,8 @@
         },
         "block-stream": {
           "version": "0.0.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "dev": true,
           "requires": {
             "inherits": "2.0.3"
@@ -6391,7 +6530,8 @@
         },
         "brace-expansion": {
           "version": "1.1.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
             "balanced-match": "1.0.0",
@@ -6400,24 +6540,28 @@
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "dev": true,
           "optional": true
         },
         "co": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6426,22 +6570,26 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true
         },
         "dashdash": {
           "version": "1.14.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6450,7 +6598,8 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -6458,7 +6607,8 @@
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6467,30 +6617,35 @@
         },
         "deep-extend": {
           "version": "0.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
           "dev": true,
           "optional": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6499,41 +6654,48 @@
         },
         "extend": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
           "dev": true,
           "optional": true
         },
         "extsprintf": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
           "dev": true
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true,
           "optional": true
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+          "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
           "dev": true,
           "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
           "dev": true,
           "optional": true
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "fstream": {
           "version": "1.0.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -6544,7 +6706,8 @@
         },
         "fstream-ignore": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6555,7 +6718,8 @@
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6571,7 +6735,8 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6580,7 +6745,8 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -6588,7 +6754,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -6601,18 +6768,21 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
             "once": "1.4.0",
@@ -6621,18 +6791,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
@@ -6640,48 +6813,56 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
           "dev": true,
           "optional": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
           "dev": true,
           "optional": true
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "dev": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
           "dev": true,
           "optional": true
         },
         "json-schema-traverse": {
           "version": "0.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
           "dev": true,
           "optional": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
           "dev": true,
           "optional": true
         },
         "jsprim": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6693,7 +6874,8 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -6701,7 +6883,8 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.8"
@@ -6709,12 +6892,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -6722,13 +6907,15 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "node-pre-gyp": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.7.0.tgz",
+          "integrity": "sha1-Va7/uu2TtQ0KRlfUaRmM2ArJ3zY=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6746,7 +6933,8 @@
           "dependencies": {
             "ajv": {
               "version": "5.5.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+              "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -6758,19 +6946,22 @@
             },
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             },
             "aws-sign2": {
               "version": "0.7.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+              "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
               "dev": true,
               "optional": true
             },
             "boom": {
               "version": "4.3.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+              "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -6779,7 +6970,8 @@
             },
             "cryptiles": {
               "version": "3.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+              "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -6788,7 +6980,8 @@
               "dependencies": {
                 "boom": {
                   "version": "5.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+                  "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -6799,7 +6992,8 @@
             },
             "form-data": {
               "version": "2.3.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+              "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -6810,7 +7004,8 @@
               "dependencies": {
                 "combined-stream": {
                   "version": "1.0.6",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+                  "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -6821,13 +7016,15 @@
             },
             "har-schema": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+              "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
               "dev": true,
               "optional": true
             },
             "har-validator": {
               "version": "5.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+              "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -6837,7 +7034,8 @@
             },
             "hawk": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+              "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -6849,12 +7047,14 @@
             },
             "hoek": {
               "version": "4.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+              "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
               "dev": true
             },
             "http-signature": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+              "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -6865,12 +7065,14 @@
             },
             "mime-db": {
               "version": "1.33.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+              "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
               "dev": true
             },
             "mime-types": {
               "version": "2.1.18",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+              "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
               "dev": true,
               "requires": {
                 "mime-db": "1.33.0"
@@ -6878,19 +7080,22 @@
             },
             "performance-now": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+              "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
               "dev": true,
               "optional": true
             },
             "qs": {
               "version": "6.5.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+              "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
               "dev": true,
               "optional": true
             },
             "request": {
               "version": "2.83.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+              "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -6920,7 +7125,8 @@
             },
             "sntp": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+              "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -6929,7 +7135,8 @@
             },
             "tough-cookie": {
               "version": "2.3.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+              "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -6940,7 +7147,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6950,7 +7158,8 @@
         },
         "npmlog": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6962,24 +7171,28 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -6987,19 +7200,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7009,23 +7225,27 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
           "dev": true
         },
         "punycode": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
+          "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7037,7 +7257,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -7045,7 +7266,8 @@
         },
         "readable-stream": {
           "version": "2.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
+          "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -7059,7 +7281,8 @@
         },
         "rimraf": {
           "version": "2.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
           "dev": true,
           "requires": {
             "glob": "7.1.2"
@@ -7067,30 +7290,35 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "sshpk": {
           "version": "1.13.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+          "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7106,7 +7334,8 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -7114,7 +7343,8 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "1.1.0",
@@ -7124,7 +7354,8 @@
         },
         "string_decoder": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.0.1"
@@ -7132,20 +7363,23 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
               "dev": true
             }
           }
         },
         "stringstream": {
           "version": "0.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
           "dev": true,
           "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
@@ -7153,13 +7387,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "2.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
           "requires": {
             "block-stream": "0.0.9",
@@ -7169,7 +7405,8 @@
         },
         "tar-pack": {
           "version": "3.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz",
+          "integrity": "sha512-PPRybI9+jM5tjtCbN2cxmmRU7YmqT3Zv/UDy48tAh2XRkLa9bAORtSWLkVc13+GJF+cdTh1yEnHEk3cpTaL5Kg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7185,7 +7422,8 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7194,30 +7432,35 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "dev": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "dev": true,
           "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true
         },
         "uuid": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
           "dev": true,
           "optional": true
         },
         "verror": {
           "version": "1.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7226,7 +7469,8 @@
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7235,7 +7479,8 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         }
       }
@@ -10486,6 +10731,9 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -12408,7 +12656,8 @@
       "dependencies": {
         "JSONStream": {
           "version": "1.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+          "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
           "requires": {
             "jsonparse": "1.3.1",
             "through": "2.3.8"
@@ -12416,41 +12665,50 @@
           "dependencies": {
             "jsonparse": {
               "version": "1.3.1",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+              "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
             },
             "through": {
               "version": "2.3.8",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
             }
           }
         },
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "ansicolors": {
           "version": "0.3.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
         },
         "ansistyles": {
           "version": "0.1.3",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+          "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk="
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
         },
         "bin-links": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-1.1.0.tgz",
+          "integrity": "sha512-3desjIEoSt86s+BRZlkLpBPPcHhr4vyUPL/+X1cQuE96NIlkELqnb4Yq+I5gZe47gHsZztA6cm38uMrT9+FWpA==",
           "requires": {
             "bluebird": "3.5.1",
             "cmd-shim": "2.0.2",
@@ -12462,11 +12720,13 @@
         },
         "bluebird": {
           "version": "3.5.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
         },
         "cacache": {
           "version": "10.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+          "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
           "requires": {
             "bluebird": "3.5.1",
             "chownr": "1.0.1",
@@ -12485,7 +12745,8 @@
           "dependencies": {
             "mississippi": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+              "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
               "requires": {
                 "concat-stream": "1.6.1",
                 "duplexify": "3.5.4",
@@ -12501,7 +12762,8 @@
               "dependencies": {
                 "concat-stream": {
                   "version": "1.6.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
+                  "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
                   "requires": {
                     "inherits": "2.0.3",
                     "readable-stream": "2.3.5",
@@ -12510,13 +12772,15 @@
                   "dependencies": {
                     "typedarray": {
                       "version": "0.0.6",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
                     }
                   }
                 },
                 "duplexify": {
                   "version": "3.5.4",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
+                  "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
                   "requires": {
                     "end-of-stream": "1.4.1",
                     "inherits": "2.0.3",
@@ -12526,20 +12790,23 @@
                   "dependencies": {
                     "stream-shift": {
                       "version": "1.0.0",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
                     }
                   }
                 },
                 "end-of-stream": {
                   "version": "1.4.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+                  "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
                   "requires": {
                     "once": "1.4.0"
                   }
                 },
                 "flush-write-stream": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+                  "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
                   "requires": {
                     "inherits": "2.0.3",
                     "readable-stream": "2.3.5"
@@ -12547,7 +12814,8 @@
                 },
                 "from2": {
                   "version": "2.3.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+                  "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
                   "requires": {
                     "inherits": "2.0.3",
                     "readable-stream": "2.3.5"
@@ -12555,7 +12823,8 @@
                 },
                 "parallel-transform": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+                  "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
                   "requires": {
                     "cyclist": "0.2.2",
                     "inherits": "2.0.3",
@@ -12564,13 +12833,15 @@
                   "dependencies": {
                     "cyclist": {
                       "version": "0.2.2",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+                      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
                     }
                   }
                 },
                 "pump": {
                   "version": "2.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+                  "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
                   "requires": {
                     "end-of-stream": "1.4.1",
                     "once": "1.4.0"
@@ -12578,7 +12849,8 @@
                 },
                 "pumpify": {
                   "version": "1.4.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
+                  "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
                   "requires": {
                     "duplexify": "3.5.4",
                     "inherits": "2.0.3",
@@ -12587,7 +12859,8 @@
                 },
                 "stream-each": {
                   "version": "1.2.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+                  "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
                   "requires": {
                     "end-of-stream": "1.4.1",
                     "stream-shift": "1.0.0"
@@ -12595,13 +12868,15 @@
                   "dependencies": {
                     "stream-shift": {
                       "version": "1.0.0",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
                     }
                   }
                 },
                 "through2": {
                   "version": "2.0.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                  "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
                   "requires": {
                     "readable-stream": "2.3.5",
                     "xtend": "4.0.1"
@@ -12609,7 +12884,8 @@
                   "dependencies": {
                     "xtend": {
                       "version": "4.0.1",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
                     }
                   }
                 }
@@ -12617,21 +12893,25 @@
             },
             "y18n": {
               "version": "4.0.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+              "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
             }
           }
         },
         "call-limit": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.0.tgz",
+          "integrity": "sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o="
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
         },
         "cli-table2": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cli-table2/-/cli-table2-0.2.0.tgz",
+          "integrity": "sha1-LR738hig54biFFQFYtS9F3/jLZc=",
           "requires": {
             "colors": "1.1.2",
             "lodash": "3.10.1",
@@ -12640,16 +12920,19 @@
           "dependencies": {
             "colors": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+              "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
               "optional": true
             },
             "lodash": {
               "version": "3.10.1",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
                 "code-point-at": "1.1.0",
                 "is-fullwidth-code-point": "1.0.0",
@@ -12658,31 +12941,36 @@
               "dependencies": {
                 "code-point-at": {
                   "version": "1.1.0",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                  "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "requires": {
                     "number-is-nan": "1.0.1"
                   },
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.1",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "requires": {
                     "ansi-regex": "2.1.1"
                   },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
                     }
                   }
                 }
@@ -12692,7 +12980,8 @@
         },
         "cmd-shim": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
+          "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
           "requires": {
             "graceful-fs": "4.1.11",
             "mkdirp": "0.5.1"
@@ -12700,7 +12989,8 @@
         },
         "columnify": {
           "version": "1.5.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+          "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
           "requires": {
             "strip-ansi": "3.0.1",
             "wcwidth": "1.0.1"
@@ -12708,34 +12998,39 @@
           "dependencies": {
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "2.1.1"
               },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
                 }
               }
             },
             "wcwidth": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+              "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
               "requires": {
                 "defaults": "1.0.3"
               },
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+                  "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
                   "requires": {
                     "clone": "1.0.2"
                   },
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+                      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
                     }
                   }
                 }
@@ -12745,7 +13040,8 @@
         },
         "config-chain": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+          "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
           "requires": {
             "ini": "1.3.5",
             "proto-list": "1.2.4"
@@ -12753,25 +13049,30 @@
           "dependencies": {
             "proto-list": {
               "version": "1.2.4",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+              "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+          "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
         },
         "detect-indent": {
           "version": "5.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
         },
         "detect-newline": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+          "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
         },
         "dezalgo": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+          "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
           "requires": {
             "asap": "2.0.5",
             "wrappy": "1.0.2"
@@ -12779,21 +13080,25 @@
           "dependencies": {
             "asap": {
               "version": "2.0.5",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+              "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8="
             }
           }
         },
         "editor": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+          "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I="
         },
         "find-npm-prefix": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz",
+          "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA=="
         },
         "fs-vacuum": {
           "version": "1.2.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
+          "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
           "requires": {
             "graceful-fs": "4.1.11",
             "path-is-inside": "1.0.2",
@@ -12802,7 +13107,8 @@
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+          "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
           "requires": {
             "graceful-fs": "4.1.11",
             "iferr": "0.1.5",
@@ -12812,7 +13118,8 @@
         },
         "gentle-fs": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.0.1.tgz",
+          "integrity": "sha512-cEng5+3fuARewXktTEGbwsktcldA+YsnUEaXZwcK/3pjSE1X9ObnTs+/8rYf8s+RnIcQm2D5x3rwpN7Zom8Bew==",
           "requires": {
             "aproba": "1.2.0",
             "fs-vacuum": "1.2.10",
@@ -12826,7 +13133,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -12838,18 +13146,21 @@
           "dependencies": {
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "requires": {
                 "brace-expansion": "1.1.8"
               },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                  "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                   "requires": {
                     "balanced-match": "1.0.0",
                     "concat-map": "0.0.1"
@@ -12857,11 +13168,13 @@
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                     }
                   }
                 }
@@ -12869,33 +13182,40 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
             }
           }
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
         },
         "hosted-git-info": {
           "version": "2.6.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+          "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
         },
         "iferr": {
           "version": "0.1.5",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+          "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
             "once": "1.4.0",
             "wrappy": "1.0.2"
@@ -12903,15 +13223,18 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "init-package-json": {
           "version": "1.10.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
+          "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
           "requires": {
             "glob": "7.1.2",
             "npm-package-arg": "6.0.0",
@@ -12925,7 +13248,8 @@
           "dependencies": {
             "promzard": {
               "version": "0.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+              "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
               "requires": {
                 "read": "1.0.7"
               }
@@ -12934,28 +13258,33 @@
         },
         "is-cidr": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-1.0.0.tgz",
+          "integrity": "sha1-+1qs9lklUxA1naMsrgPkDGocKvw=",
           "requires": {
             "cidr-regex": "1.0.6"
           },
           "dependencies": {
             "cidr-regex": {
               "version": "1.0.6",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-1.0.6.tgz",
+              "integrity": "sha1-dKv9YZ3zcLnVSrFEdVaOl91kwME="
             }
           }
         },
         "json-parse-better-errors": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+          "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw=="
         },
         "lazy-property": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
+          "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc="
         },
         "libcipm": {
           "version": "1.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libcipm/-/libcipm-1.6.0.tgz",
+          "integrity": "sha512-HpV3ibmHSAOiDVYIDOM2uDlfkkmglivsavGn6RwJDne+PjXeNQyHAwXddikfsPqxc0OP6GsHJwrwaxhCHZs8Dg==",
           "requires": {
             "bin-links": "1.1.0",
             "bluebird": "3.5.1",
@@ -12974,7 +13303,8 @@
           "dependencies": {
             "lock-verify": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lock-verify/-/lock-verify-2.0.0.tgz",
+              "integrity": "sha512-ZK+fx1rQBBvyRp12tPgKaMrKlxv+72hO+QCAvdW8BGwKx/Jn3wVD7GooG2ftF80W29hfj+R1o0tTI8m6/pl1Mw==",
               "requires": {
                 "npm-package-arg": "5.1.2",
                 "semver": "5.5.0"
@@ -12982,7 +13312,8 @@
               "dependencies": {
                 "npm-package-arg": {
                   "version": "5.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
+                  "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
                   "requires": {
                     "hosted-git-info": "2.6.0",
                     "osenv": "0.1.5",
@@ -12994,24 +13325,28 @@
             },
             "npm-logical-tree": {
               "version": "1.2.1",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz",
+              "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg=="
             },
             "protoduck": {
               "version": "5.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.0.tgz",
+              "integrity": "sha512-agsGWD8/RZrS4ga6v82Fxb0RHIS2RZnbsSue6A9/MBRhB/jcqOANAMNrqM9900b8duj+Gx+T/JMy5IowDoO/hQ==",
               "requires": {
                 "genfun": "4.0.1"
               },
               "dependencies": {
                 "genfun": {
                   "version": "4.0.1",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/genfun/-/genfun-4.0.1.tgz",
+                  "integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E="
                 }
               }
             },
             "worker-farm": {
               "version": "1.5.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.4.tgz",
+              "integrity": "sha512-ITyClEvcfv0ozqJl1vmWFWhvI+OIrkbInYqkEPE50wFPXj8J9Gd3FYf8+CkZJXJJsQBYe+2DvmoK9Zhx5w8W+w==",
               "requires": {
                 "errno": "0.1.7",
                 "xtend": "4.0.1"
@@ -13019,20 +13354,23 @@
               "dependencies": {
                 "errno": {
                   "version": "0.1.7",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+                  "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
                   "requires": {
                     "prr": "1.0.1"
                   },
                   "dependencies": {
                     "prr": {
                       "version": "1.0.1",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+                      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
                 }
               }
             }
@@ -13040,7 +13378,8 @@
         },
         "libnpx": {
           "version": "10.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libnpx/-/libnpx-10.0.1.tgz",
+          "integrity": "sha512-87491jxL9jeP2rDF4px3JNHTKCsHFTRAuRkGZ9/b0vb/312mxFCAsuNcGvbw0BTED0iGf+IeNDgBGy9lcy3pTQ==",
           "requires": {
             "dotenv": "5.0.1",
             "npm-package-arg": "6.0.0",
@@ -13054,15 +13393,18 @@
           "dependencies": {
             "dotenv": {
               "version": "5.0.1",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+              "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
             },
             "y18n": {
               "version": "4.0.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+              "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
             },
             "yargs": {
               "version": "11.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+              "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
               "requires": {
                 "cliui": "4.0.0",
                 "decamelize": "1.2.0",
@@ -13080,7 +13422,8 @@
               "dependencies": {
                 "cliui": {
                   "version": "4.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+                  "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
                   "requires": {
                     "string-width": "2.1.1",
                     "strip-ansi": "4.0.0",
@@ -13089,7 +13432,8 @@
                   "dependencies": {
                     "wrap-ansi": {
                       "version": "2.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+                      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
                       "requires": {
                         "string-width": "1.0.2",
                         "strip-ansi": "3.0.1"
@@ -13097,7 +13441,8 @@
                       "dependencies": {
                         "string-width": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                           "requires": {
                             "code-point-at": "1.1.0",
                             "is-fullwidth-code-point": "1.0.0",
@@ -13106,18 +13451,21 @@
                           "dependencies": {
                             "code-point-at": {
                               "version": "1.1.0",
-                              "bundled": true
+                              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
                             },
                             "is-fullwidth-code-point": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                               "requires": {
                                 "number-is-nan": "1.0.1"
                               },
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.1",
-                                  "bundled": true
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                                  "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
                                 }
                               }
                             }
@@ -13125,14 +13473,16 @@
                         },
                         "strip-ansi": {
                           "version": "3.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                           "requires": {
                             "ansi-regex": "2.1.1"
                           },
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
-                              "bundled": true
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
                             }
                           }
                         }
@@ -13142,18 +13492,21 @@
                 },
                 "decamelize": {
                   "version": "1.2.0",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                  "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
                 },
                 "find-up": {
                   "version": "2.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                  "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                   "requires": {
                     "locate-path": "2.0.0"
                   },
                   "dependencies": {
                     "locate-path": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
                       "requires": {
                         "p-locate": "2.0.0",
                         "path-exists": "3.0.0"
@@ -13161,21 +13514,24 @@
                       "dependencies": {
                         "p-locate": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
                           "requires": {
                             "p-limit": "1.2.0"
                           },
                           "dependencies": {
                             "p-limit": {
                               "version": "1.2.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+                              "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
                               "requires": {
                                 "p-try": "1.0.0"
                               },
                               "dependencies": {
                                 "p-try": {
                                   "version": "1.0.0",
-                                  "bundled": true
+                                  "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                                  "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
                                 }
                               }
                             }
@@ -13183,7 +13539,8 @@
                         },
                         "path-exists": {
                           "version": "3.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
                         }
                       }
                     }
@@ -13191,11 +13548,13 @@
                 },
                 "get-caller-file": {
                   "version": "1.0.2",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+                  "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
                 },
                 "os-locale": {
                   "version": "2.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+                  "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
                   "requires": {
                     "execa": "0.7.0",
                     "lcid": "1.0.0",
@@ -13204,7 +13563,8 @@
                   "dependencies": {
                     "execa": {
                       "version": "0.7.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+                      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                       "requires": {
                         "cross-spawn": "5.1.0",
                         "get-stream": "3.0.0",
@@ -13217,7 +13577,8 @@
                       "dependencies": {
                         "cross-spawn": {
                           "version": "5.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                           "requires": {
                             "lru-cache": "4.1.1",
                             "shebang-command": "1.2.0",
@@ -13226,14 +13587,16 @@
                           "dependencies": {
                             "shebang-command": {
                               "version": "1.2.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                              "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
                               "requires": {
                                 "shebang-regex": "1.0.0"
                               },
                               "dependencies": {
                                 "shebang-regex": {
                                   "version": "1.0.0",
-                                  "bundled": true
+                                  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                                  "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
                                 }
                               }
                             }
@@ -13241,62 +13604,73 @@
                         },
                         "get-stream": {
                           "version": "3.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
                         },
                         "is-stream": {
                           "version": "1.1.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
                         },
                         "npm-run-path": {
                           "version": "2.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+                          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
                           "requires": {
                             "path-key": "2.0.1"
                           },
                           "dependencies": {
                             "path-key": {
                               "version": "2.0.1",
-                              "bundled": true
+                              "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                              "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
                             }
                           }
                         },
                         "p-finally": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+                          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
                         },
                         "signal-exit": {
                           "version": "3.0.2",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
                         },
                         "strip-eof": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+                          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
                         }
                       }
                     },
                     "lcid": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
                       "requires": {
                         "invert-kv": "1.0.0"
                       },
                       "dependencies": {
                         "invert-kv": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
                         }
                       }
                     },
                     "mem": {
                       "version": "1.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+                      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
                       "requires": {
                         "mimic-fn": "1.2.0"
                       },
                       "dependencies": {
                         "mimic-fn": {
                           "version": "1.2.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+                          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
                         }
                       }
                     }
@@ -13304,19 +13678,23 @@
                 },
                 "require-directory": {
                   "version": "2.1.1",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+                  "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
                 },
                 "require-main-filename": {
                   "version": "1.0.1",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+                  "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
                 },
                 "set-blocking": {
                   "version": "2.0.0",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
                 },
                 "string-width": {
                   "version": "2.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                  "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                   "requires": {
                     "is-fullwidth-code-point": "2.0.0",
                     "strip-ansi": "4.0.0"
@@ -13324,28 +13702,33 @@
                   "dependencies": {
                     "is-fullwidth-code-point": {
                       "version": "2.0.0",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
                     }
                   }
                 },
                 "which-module": {
                   "version": "2.0.0",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                  "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
                 },
                 "y18n": {
                   "version": "3.2.1",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+                  "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
                 },
                 "yargs-parser": {
                   "version": "9.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+                  "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
                   "requires": {
                     "camelcase": "4.1.0"
                   },
                   "dependencies": {
                     "camelcase": {
                       "version": "4.1.0",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
                     }
                   }
                 }
@@ -13355,15 +13738,18 @@
         },
         "lockfile": {
           "version": "1.0.3",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz",
+          "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k="
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+          "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw="
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+          "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
           "requires": {
             "lodash._createset": "4.0.3",
             "lodash._root": "3.0.1"
@@ -13371,56 +13757,68 @@
           "dependencies": {
             "lodash._createset": {
               "version": "4.0.3",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+              "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY="
             },
             "lodash._root": {
               "version": "3.0.1",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+              "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
             }
           }
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+          "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI="
         },
         "lodash._createcache": {
           "version": "3.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+          "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
           "requires": {
             "lodash._getnative": "3.9.1"
           }
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+          "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
         },
         "lodash.union": {
           "version": "4.6.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+          "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
         },
         "lodash.uniq": {
           "version": "4.5.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+          "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
         },
         "lodash.without": {
           "version": "4.4.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+          "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
         },
         "lru-cache": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
           "requires": {
             "pseudomap": "1.0.2",
             "yallist": "2.1.2"
@@ -13428,21 +13826,25 @@
           "dependencies": {
             "pseudomap": {
               "version": "1.0.2",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+              "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
             },
             "yallist": {
               "version": "2.1.2",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
             }
           }
         },
         "meant": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/meant/-/meant-1.0.1.tgz",
+          "integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg=="
         },
         "mississippi": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+          "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
           "requires": {
             "concat-stream": "1.6.1",
             "duplexify": "3.5.4",
@@ -13458,7 +13860,8 @@
           "dependencies": {
             "concat-stream": {
               "version": "1.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
+              "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
               "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "2.3.5",
@@ -13467,13 +13870,15 @@
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
                 }
               }
             },
             "duplexify": {
               "version": "3.5.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
+              "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
               "requires": {
                 "end-of-stream": "1.4.1",
                 "inherits": "2.0.3",
@@ -13483,20 +13888,23 @@
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                  "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
                 }
               }
             },
             "end-of-stream": {
               "version": "1.4.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+              "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
               "requires": {
                 "once": "1.4.0"
               }
             },
             "flush-write-stream": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+              "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
               "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "2.3.5"
@@ -13504,7 +13912,8 @@
             },
             "from2": {
               "version": "2.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+              "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
               "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "2.3.5"
@@ -13512,7 +13921,8 @@
             },
             "parallel-transform": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+              "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
               "requires": {
                 "cyclist": "0.2.2",
                 "inherits": "2.0.3",
@@ -13521,13 +13931,15 @@
               "dependencies": {
                 "cyclist": {
                   "version": "0.2.2",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+                  "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
                 }
               }
             },
             "pump": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+              "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
               "requires": {
                 "end-of-stream": "1.4.1",
                 "once": "1.4.0"
@@ -13535,7 +13947,8 @@
             },
             "pumpify": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
+              "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
               "requires": {
                 "duplexify": "3.5.4",
                 "inherits": "2.0.3",
@@ -13544,7 +13957,8 @@
               "dependencies": {
                 "pump": {
                   "version": "2.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+                  "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
                   "requires": {
                     "end-of-stream": "1.4.1",
                     "once": "1.4.0"
@@ -13554,7 +13968,8 @@
             },
             "stream-each": {
               "version": "1.2.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+              "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
               "requires": {
                 "end-of-stream": "1.4.1",
                 "stream-shift": "1.0.0"
@@ -13562,13 +13977,15 @@
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                  "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
                 }
               }
             },
             "through2": {
               "version": "2.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+              "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
               "requires": {
                 "readable-stream": "2.3.5",
                 "xtend": "4.0.1"
@@ -13576,7 +13993,8 @@
               "dependencies": {
                 "xtend": {
                   "version": "4.0.1",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
                 }
               }
             }
@@ -13584,20 +14002,23 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
           },
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
             }
           }
         },
         "move-concurrently": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+          "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
           "requires": {
             "aproba": "1.2.0",
             "copy-concurrently": "1.0.5",
@@ -13609,7 +14030,8 @@
           "dependencies": {
             "copy-concurrently": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+              "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
               "requires": {
                 "aproba": "1.2.0",
                 "fs-write-stream-atomic": "1.0.10",
@@ -13621,7 +14043,8 @@
             },
             "run-queue": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+              "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
               "requires": {
                 "aproba": "1.2.0"
               }
@@ -13630,7 +14053,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "requires": {
             "abbrev": "1.1.1",
             "osenv": "0.1.5"
@@ -13638,7 +14062,8 @@
         },
         "normalize-package-data": {
           "version": "2.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "requires": {
             "hosted-git-info": "2.6.0",
             "is-builtin-module": "1.0.0",
@@ -13648,14 +14073,16 @@
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+              "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
               "requires": {
                 "builtin-modules": "1.1.1"
               },
               "dependencies": {
                 "builtin-modules": {
                   "version": "1.1.1",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                  "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
                 }
               }
             }
@@ -13663,18 +14090,21 @@
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+          "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE="
         },
         "npm-install-checks": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.0.tgz",
+          "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
           "requires": {
             "semver": "5.5.0"
           }
         },
         "npm-lifecycle": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-2.0.1.tgz",
+          "integrity": "sha512-6CypRO6iNsSfrWOUajeQnesouUgkeh7clByYDORUV6AhwRaGfHYh+5rFdDCIqzmMqomGlyDsSpazthNPG2BAOA==",
           "requires": {
             "byline": "5.0.0",
             "graceful-fs": "4.1.11",
@@ -13688,11 +14118,13 @@
           "dependencies": {
             "byline": {
               "version": "5.0.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+              "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
             },
             "node-gyp": {
               "version": "3.6.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+              "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
               "requires": {
                 "fstream": "1.0.11",
                 "glob": "7.1.2",
@@ -13711,7 +14143,8 @@
               "dependencies": {
                 "fstream": {
                   "version": "1.0.11",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+                  "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
                   "requires": {
                     "graceful-fs": "4.1.11",
                     "inherits": "2.0.3",
@@ -13721,14 +14154,16 @@
                 },
                 "minimatch": {
                   "version": "3.0.4",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "requires": {
                     "brace-expansion": "1.1.11"
                   },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.11",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+                      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                       "requires": {
                         "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
@@ -13736,11 +14171,13 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                         }
                       }
                     }
@@ -13748,18 +14185,21 @@
                 },
                 "nopt": {
                   "version": "3.0.6",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                  "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
                   "requires": {
                     "abbrev": "1.1.1"
                   }
                 },
                 "semver": {
                   "version": "5.3.0",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+                  "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
                 },
                 "tar": {
                   "version": "2.2.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+                  "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
                   "requires": {
                     "block-stream": "0.0.9",
                     "fstream": "1.0.11",
@@ -13768,7 +14208,8 @@
                   "dependencies": {
                     "block-stream": {
                       "version": "0.0.9",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+                      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
                       "requires": {
                         "inherits": "2.0.3"
                       }
@@ -13779,13 +14220,15 @@
             },
             "resolve-from": {
               "version": "4.0.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+              "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
             }
           }
         },
         "npm-package-arg": {
           "version": "6.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.0.0.tgz",
+          "integrity": "sha512-hwC7g81KLgRmchv9ol6f3Fx4Yyc9ARX5X5niDHVILgpuvf08JRIgOZcEfpFXli3BgESoTrkauqorXm6UbvSgSg==",
           "requires": {
             "hosted-git-info": "2.6.0",
             "osenv": "0.1.5",
@@ -13795,7 +14238,8 @@
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "requires": {
             "ignore-walk": "3.0.1",
             "npm-bundled": "1.0.3"
@@ -13803,21 +14247,24 @@
           "dependencies": {
             "ignore-walk": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+              "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
               "requires": {
                 "minimatch": "3.0.4"
               },
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "requires": {
                     "brace-expansion": "1.1.8"
                   },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                       "requires": {
                         "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
@@ -13825,11 +14272,13 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                         }
                       }
                     }
@@ -13839,13 +14288,15 @@
             },
             "npm-bundled": {
               "version": "1.0.3",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+              "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow=="
             }
           }
         },
         "npm-profile": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-3.0.1.tgz",
+          "integrity": "sha512-U/jvnERvBRYgIdHkPURsa8mjLCOiImdA8fw1FzzCF//PKro4w1QANCmXiQex8f/Id1h939lqOiUT+ywKL0AG4Q==",
           "requires": {
             "aproba": "1.2.0",
             "make-fetch-happen": "2.6.0"
@@ -13853,7 +14304,8 @@
           "dependencies": {
             "make-fetch-happen": {
               "version": "2.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-2.6.0.tgz",
+              "integrity": "sha512-FFq0lNI0ax+n9IWzWpH8A4JdgYiAp2DDYIZ3rsaav8JDe8I+72CzK6PQW/oom15YDZpV5bYW/9INd6nIJ2ZfZw==",
               "requires": {
                 "agentkeepalive": "3.3.0",
                 "cacache": "10.0.4",
@@ -13870,21 +14322,24 @@
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.3.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.3.0.tgz",
+                  "integrity": "sha512-9yhcpXti2ZQE7bxuCsjjWNIZoQOd9sZ1ZBovHG0YeCRohFv73SLvcm73PC9T3olM4GyozaQb+4MGdQpcD8m7NQ==",
                   "requires": {
                     "humanize-ms": "1.2.1"
                   },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+                      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
                       "requires": {
                         "ms": "2.1.1"
                       },
                       "dependencies": {
                         "ms": {
                           "version": "2.1.1",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
                         }
                       }
                     }
@@ -13892,11 +14347,13 @@
                 },
                 "http-cache-semantics": {
                   "version": "3.8.1",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+                  "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
                 },
                 "http-proxy-agent": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.0.0.tgz",
+                  "integrity": "sha1-RkgqLwUjpNYIJVFwn0acs+SoX/Q=",
                   "requires": {
                     "agent-base": "4.2.0",
                     "debug": "2.6.9"
@@ -13904,21 +14361,24 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+                      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
                       "requires": {
                         "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "requires": {
                             "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.2.4",
-                              "bundled": true
+                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+                              "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
                             }
                           }
                         }
@@ -13926,14 +14386,16 @@
                     },
                     "debug": {
                       "version": "2.6.9",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
                       "requires": {
                         "ms": "2.0.0"
                       },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                         }
                       }
                     }
@@ -13941,7 +14403,8 @@
                 },
                 "https-proxy-agent": {
                   "version": "2.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz",
+                  "integrity": "sha512-LK6tQUR/VOkTI6ygAfWUKKP95I+e6M1h7N3PncGu1CATHCnex+CAv9ttR0lbHu1Uk2PXm/WoAHFo6JCGwMjVMw==",
                   "requires": {
                     "agent-base": "4.2.0",
                     "debug": "3.1.0"
@@ -13949,21 +14412,24 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+                      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
                       "requires": {
                         "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "requires": {
                             "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.2.4",
-                              "bundled": true
+                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+                              "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
                             }
                           }
                         }
@@ -13971,14 +14437,16 @@
                     },
                     "debug": {
                       "version": "3.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
                       "requires": {
                         "ms": "2.0.0"
                       },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                         }
                       }
                     }
@@ -13986,7 +14454,8 @@
                 },
                 "mississippi": {
                   "version": "1.3.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.1.tgz",
+                  "integrity": "sha512-/6rB8YXFbAtsUVRphIRQqB0+9c7VaPHCjVtvto+JqwVxgz8Zz+I+f68/JgQ+Pb4VlZb2svA9OtdXnHHsZz7ltg==",
                   "requires": {
                     "concat-stream": "1.6.0",
                     "duplexify": "3.5.3",
@@ -14002,7 +14471,8 @@
                   "dependencies": {
                     "concat-stream": {
                       "version": "1.6.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+                      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
                       "requires": {
                         "inherits": "2.0.3",
                         "readable-stream": "2.3.5",
@@ -14011,13 +14481,15 @@
                       "dependencies": {
                         "typedarray": {
                           "version": "0.0.6",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
                         }
                       }
                     },
                     "duplexify": {
                       "version": "3.5.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
+                      "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
                       "requires": {
                         "end-of-stream": "1.4.1",
                         "inherits": "2.0.3",
@@ -14027,20 +14499,23 @@
                       "dependencies": {
                         "stream-shift": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                          "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
                         }
                       }
                     },
                     "end-of-stream": {
                       "version": "1.4.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+                      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
                       "requires": {
                         "once": "1.4.0"
                       }
                     },
                     "flush-write-stream": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+                      "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
                       "requires": {
                         "inherits": "2.0.3",
                         "readable-stream": "2.3.5"
@@ -14048,7 +14523,8 @@
                     },
                     "from2": {
                       "version": "2.3.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+                      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
                       "requires": {
                         "inherits": "2.0.3",
                         "readable-stream": "2.3.5"
@@ -14056,7 +14532,8 @@
                     },
                     "parallel-transform": {
                       "version": "1.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+                      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
                       "requires": {
                         "cyclist": "0.2.2",
                         "inherits": "2.0.3",
@@ -14065,13 +14542,15 @@
                       "dependencies": {
                         "cyclist": {
                           "version": "0.2.2",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+                          "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
                         }
                       }
                     },
                     "pump": {
                       "version": "1.0.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+                      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
                       "requires": {
                         "end-of-stream": "1.4.1",
                         "once": "1.4.0"
@@ -14079,7 +14558,8 @@
                     },
                     "pumpify": {
                       "version": "1.4.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
+                      "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
                       "requires": {
                         "duplexify": "3.5.3",
                         "inherits": "2.0.3",
@@ -14088,7 +14568,8 @@
                       "dependencies": {
                         "pump": {
                           "version": "2.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+                          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
                           "requires": {
                             "end-of-stream": "1.4.1",
                             "once": "1.4.0"
@@ -14098,7 +14579,8 @@
                     },
                     "stream-each": {
                       "version": "1.2.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+                      "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
                       "requires": {
                         "end-of-stream": "1.4.1",
                         "stream-shift": "1.0.0"
@@ -14106,13 +14588,15 @@
                       "dependencies": {
                         "stream-shift": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                          "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
                         }
                       }
                     },
                     "through2": {
                       "version": "2.0.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
                       "requires": {
                         "readable-stream": "2.3.5",
                         "xtend": "4.0.1"
@@ -14120,7 +14604,8 @@
                       "dependencies": {
                         "xtend": {
                           "version": "4.0.1",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
                         }
                       }
                     }
@@ -14128,7 +14613,8 @@
                 },
                 "node-fetch-npm": {
                   "version": "2.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
+                  "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
                   "requires": {
                     "encoding": "0.1.12",
                     "json-parse-better-errors": "1.0.1",
@@ -14137,26 +14623,30 @@
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
                       "requires": {
                         "iconv-lite": "0.4.19"
                       },
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.19",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+                          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
                         }
                       }
                     },
                     "json-parse-better-errors": {
                       "version": "1.0.1",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+                      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw=="
                     }
                   }
                 },
                 "promise-retry": {
                   "version": "1.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+                  "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
                   "requires": {
                     "err-code": "1.1.2",
                     "retry": "0.10.1"
@@ -14164,13 +14654,15 @@
                   "dependencies": {
                     "err-code": {
                       "version": "1.1.2",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+                      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
                     }
                   }
                 },
                 "socks-proxy-agent": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
+                  "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
                   "requires": {
                     "agent-base": "4.2.0",
                     "socks": "1.1.10"
@@ -14178,21 +14670,24 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+                      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
                       "requires": {
                         "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "requires": {
                             "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.2.4",
-                              "bundled": true
+                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+                              "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
                             }
                           }
                         }
@@ -14200,7 +14695,8 @@
                     },
                     "socks": {
                       "version": "1.1.10",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+                      "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
                       "requires": {
                         "ip": "1.1.5",
                         "smart-buffer": "1.1.15"
@@ -14208,11 +14704,13 @@
                       "dependencies": {
                         "ip": {
                           "version": "1.1.5",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+                          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
                         },
                         "smart-buffer": {
                           "version": "1.1.15",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+                          "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
                         }
                       }
                     }
@@ -14224,7 +14722,8 @@
         },
         "npm-registry-client": {
           "version": "8.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.5.1.tgz",
+          "integrity": "sha512-7rjGF2eA7hKDidGyEWmHTiKfXkbrcQAsGL/Rh4Rt3x3YNRNHhwaTzVJfW3aNvvlhg4G62VCluif0sLCb/i51Hg==",
           "requires": {
             "concat-stream": "1.6.1",
             "graceful-fs": "4.1.11",
@@ -14242,7 +14741,8 @@
           "dependencies": {
             "concat-stream": {
               "version": "1.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
+              "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
               "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "2.3.5",
@@ -14251,7 +14751,8 @@
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
                 }
               }
             }
@@ -14259,11 +14760,13 @@
         },
         "npm-user-validate": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.0.tgz",
+          "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE="
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "requires": {
             "are-we-there-yet": "1.1.4",
             "console-control-strings": "1.1.0",
@@ -14273,7 +14776,8 @@
           "dependencies": {
             "are-we-there-yet": {
               "version": "1.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+              "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
               "requires": {
                 "delegates": "1.0.0",
                 "readable-stream": "2.3.5"
@@ -14281,17 +14785,20 @@
               "dependencies": {
                 "delegates": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                  "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
                 }
               }
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
             },
             "gauge": {
               "version": "2.7.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "requires": {
                 "aproba": "1.2.0",
                 "console-control-strings": "1.1.0",
@@ -14305,15 +14812,18 @@
               "dependencies": {
                 "object-assign": {
                   "version": "4.1.1",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                  "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
                 },
                 "signal-exit": {
                   "version": "3.0.2",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                  "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
                 },
                 "string-width": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "requires": {
                     "code-point-at": "1.1.0",
                     "is-fullwidth-code-point": "1.0.0",
@@ -14322,18 +14832,21 @@
                   "dependencies": {
                     "code-point-at": {
                       "version": "1.1.0",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
                     },
                     "is-fullwidth-code-point": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                       "requires": {
                         "number-is-nan": "1.0.1"
                       },
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.1",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
                         }
                       }
                     }
@@ -14341,20 +14854,23 @@
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "requires": {
                     "ansi-regex": "2.1.1"
                   },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
                     }
                   }
                 },
                 "wide-align": {
                   "version": "1.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+                  "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
                   "requires": {
                     "string-width": "1.0.2"
                   }
@@ -14363,24 +14879,28 @@
             },
             "set-blocking": {
               "version": "2.0.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
             }
           }
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1.0.2"
           }
         },
         "opener": {
           "version": "1.4.3",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
+          "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg="
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "requires": {
             "os-homedir": "1.0.2",
             "os-tmpdir": "1.0.2"
@@ -14388,17 +14908,20 @@
           "dependencies": {
             "os-homedir": {
               "version": "1.0.2",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
             }
           }
         },
         "pacote": {
           "version": "7.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pacote/-/pacote-7.6.1.tgz",
+          "integrity": "sha512-2kRIsHxjuYC1KRUIK80AFIXKWy0IgtFj76nKcaunozKAOSlfT+DFh3EfeaaKvNHCWixgi0G0rLg11lJeyEnp/Q==",
           "requires": {
             "bluebird": "3.5.1",
             "cacache": "10.0.4",
@@ -14428,11 +14951,13 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
             },
             "make-fetch-happen": {
               "version": "2.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-2.6.0.tgz",
+              "integrity": "sha512-FFq0lNI0ax+n9IWzWpH8A4JdgYiAp2DDYIZ3rsaav8JDe8I+72CzK6PQW/oom15YDZpV5bYW/9INd6nIJ2ZfZw==",
               "requires": {
                 "agentkeepalive": "3.4.0",
                 "cacache": "10.0.4",
@@ -14449,21 +14974,24 @@
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.4.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.4.0.tgz",
+                  "integrity": "sha512-RypT3apziwtLsJTtab5kzqADuzWaYVqFPQo7X8QSYuteaw9GGNPsB5fTy8BVcCVish3cD9yLroR7oUVlZybhpQ==",
                   "requires": {
                     "humanize-ms": "1.2.1"
                   },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+                      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
                       "requires": {
                         "ms": "2.1.1"
                       },
                       "dependencies": {
                         "ms": {
                           "version": "2.1.1",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
                         }
                       }
                     }
@@ -14471,11 +14999,13 @@
                 },
                 "http-cache-semantics": {
                   "version": "3.8.1",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+                  "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
                 },
                 "http-proxy-agent": {
                   "version": "2.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+                  "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
                   "requires": {
                     "agent-base": "4.2.0",
                     "debug": "3.1.0"
@@ -14483,21 +15013,24 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+                      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
                       "requires": {
                         "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "requires": {
                             "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.2.4",
-                              "bundled": true
+                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+                              "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
                             }
                           }
                         }
@@ -14505,14 +15038,16 @@
                     },
                     "debug": {
                       "version": "3.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
                       "requires": {
                         "ms": "2.0.0"
                       },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                         }
                       }
                     }
@@ -14520,7 +15055,8 @@
                 },
                 "https-proxy-agent": {
                   "version": "2.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.0.tgz",
+                  "integrity": "sha512-uUWcfXHvy/dwfM9bqa6AozvAjS32dZSTUYd/4SEpYKRg6LEcPLshksnQYRudM9AyNvUARMfAg5TLjUDyX/K4vA==",
                   "requires": {
                     "agent-base": "4.2.0",
                     "debug": "3.1.0"
@@ -14528,21 +15064,24 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+                      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
                       "requires": {
                         "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "requires": {
                             "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.2.4",
-                              "bundled": true
+                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+                              "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
                             }
                           }
                         }
@@ -14550,14 +15089,16 @@
                     },
                     "debug": {
                       "version": "3.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
                       "requires": {
                         "ms": "2.0.0"
                       },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                         }
                       }
                     }
@@ -14565,7 +15106,8 @@
                 },
                 "mississippi": {
                   "version": "1.3.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.1.tgz",
+                  "integrity": "sha512-/6rB8YXFbAtsUVRphIRQqB0+9c7VaPHCjVtvto+JqwVxgz8Zz+I+f68/JgQ+Pb4VlZb2svA9OtdXnHHsZz7ltg==",
                   "requires": {
                     "concat-stream": "1.6.1",
                     "duplexify": "3.5.4",
@@ -14581,7 +15123,8 @@
                   "dependencies": {
                     "concat-stream": {
                       "version": "1.6.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
+                      "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
                       "requires": {
                         "inherits": "2.0.3",
                         "readable-stream": "2.3.5",
@@ -14590,13 +15133,15 @@
                       "dependencies": {
                         "typedarray": {
                           "version": "0.0.6",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
                         }
                       }
                     },
                     "duplexify": {
                       "version": "3.5.4",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
+                      "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
                       "requires": {
                         "end-of-stream": "1.4.1",
                         "inherits": "2.0.3",
@@ -14606,20 +15151,23 @@
                       "dependencies": {
                         "stream-shift": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                          "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
                         }
                       }
                     },
                     "end-of-stream": {
                       "version": "1.4.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+                      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
                       "requires": {
                         "once": "1.4.0"
                       }
                     },
                     "flush-write-stream": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+                      "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
                       "requires": {
                         "inherits": "2.0.3",
                         "readable-stream": "2.3.5"
@@ -14627,7 +15175,8 @@
                     },
                     "from2": {
                       "version": "2.3.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+                      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
                       "requires": {
                         "inherits": "2.0.3",
                         "readable-stream": "2.3.5"
@@ -14635,7 +15184,8 @@
                     },
                     "parallel-transform": {
                       "version": "1.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+                      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
                       "requires": {
                         "cyclist": "0.2.2",
                         "inherits": "2.0.3",
@@ -14644,13 +15194,15 @@
                       "dependencies": {
                         "cyclist": {
                           "version": "0.2.2",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+                          "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
                         }
                       }
                     },
                     "pump": {
                       "version": "1.0.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+                      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
                       "requires": {
                         "end-of-stream": "1.4.1",
                         "once": "1.4.0"
@@ -14658,7 +15210,8 @@
                     },
                     "pumpify": {
                       "version": "1.4.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
+                      "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
                       "requires": {
                         "duplexify": "3.5.4",
                         "inherits": "2.0.3",
@@ -14667,7 +15220,8 @@
                       "dependencies": {
                         "pump": {
                           "version": "2.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+                          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
                           "requires": {
                             "end-of-stream": "1.4.1",
                             "once": "1.4.0"
@@ -14677,7 +15231,8 @@
                     },
                     "stream-each": {
                       "version": "1.2.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+                      "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
                       "requires": {
                         "end-of-stream": "1.4.1",
                         "stream-shift": "1.0.0"
@@ -14685,13 +15240,15 @@
                       "dependencies": {
                         "stream-shift": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                          "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
                         }
                       }
                     },
                     "through2": {
                       "version": "2.0.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
                       "requires": {
                         "readable-stream": "2.3.5",
                         "xtend": "4.0.1"
@@ -14699,7 +15256,8 @@
                       "dependencies": {
                         "xtend": {
                           "version": "4.0.1",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
                         }
                       }
                     }
@@ -14707,7 +15265,8 @@
                 },
                 "node-fetch-npm": {
                   "version": "2.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
+                  "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
                   "requires": {
                     "encoding": "0.1.12",
                     "json-parse-better-errors": "1.0.1",
@@ -14716,26 +15275,30 @@
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
                       "requires": {
                         "iconv-lite": "0.4.19"
                       },
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.19",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+                          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
                         }
                       }
                     },
                     "json-parse-better-errors": {
                       "version": "1.0.1",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+                      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw=="
                     }
                   }
                 },
                 "socks-proxy-agent": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
+                  "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
                   "requires": {
                     "agent-base": "4.2.0",
                     "socks": "1.1.10"
@@ -14743,21 +15306,24 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+                      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
                       "requires": {
                         "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "requires": {
                             "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.2.4",
-                              "bundled": true
+                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+                              "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
                             }
                           }
                         }
@@ -14765,7 +15331,8 @@
                     },
                     "socks": {
                       "version": "1.1.10",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+                      "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
                       "requires": {
                         "ip": "1.1.5",
                         "smart-buffer": "1.1.15"
@@ -14773,11 +15340,13 @@
                       "dependencies": {
                         "ip": {
                           "version": "1.1.5",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+                          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
                         },
                         "smart-buffer": {
                           "version": "1.1.15",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+                          "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
                         }
                       }
                     }
@@ -14787,14 +15356,16 @@
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "requires": {
                 "brace-expansion": "1.1.11"
               },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.11",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+                  "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                   "requires": {
                     "balanced-match": "1.0.0",
                     "concat-map": "0.0.1"
@@ -14802,11 +15373,13 @@
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                     }
                   }
                 }
@@ -14814,7 +15387,8 @@
             },
             "npm-pick-manifest": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-2.1.0.tgz",
+              "integrity": "sha512-q9zLP8cTr8xKPmMZN3naxp1k/NxVFsjxN6uWuO1tiw9gxg7wZWQ/b5UTfzD0ANw2q1lQxdLKTeCCksq+bPSgbQ==",
               "requires": {
                 "npm-package-arg": "6.0.0",
                 "semver": "5.5.0"
@@ -14822,7 +15396,8 @@
             },
             "promise-retry": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+              "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
               "requires": {
                 "err-code": "1.1.2",
                 "retry": "0.10.1"
@@ -14830,20 +15405,23 @@
               "dependencies": {
                 "err-code": {
                   "version": "1.1.2",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+                  "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
                 }
               }
             },
             "protoduck": {
               "version": "5.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.0.tgz",
+              "integrity": "sha512-agsGWD8/RZrS4ga6v82Fxb0RHIS2RZnbsSue6A9/MBRhB/jcqOANAMNrqM9900b8duj+Gx+T/JMy5IowDoO/hQ==",
               "requires": {
                 "genfun": "4.0.1"
               },
               "dependencies": {
                 "genfun": {
                   "version": "4.0.1",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/genfun/-/genfun-4.0.1.tgz",
+                  "integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E="
                 }
               }
             }
@@ -14851,19 +15429,23 @@
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+          "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
         },
         "qrcode-terminal": {
           "version": "0.11.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.11.0.tgz",
+          "integrity": "sha1-/8bCii/Av7RwUrR+I/T0RqX7254="
         },
         "query-string": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.0.tgz",
+          "integrity": "sha512-F3DkxxlY0AqD/rwe4YAwjRE2HjOkKW7TxsuteyrS/Jbwrxw887PqYBL4sWUJ9D/V1hmFns0SCD6FDyvlwo9RCQ==",
           "requires": {
             "decode-uri-component": "0.2.0",
             "object-assign": "4.1.1",
@@ -14872,45 +15454,53 @@
           "dependencies": {
             "decode-uri-component": {
               "version": "0.2.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+              "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
             },
             "object-assign": {
               "version": "4.1.1",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
             },
             "strict-uri-encode": {
               "version": "1.1.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+              "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
             }
           }
         },
         "qw": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/qw/-/qw-1.0.1.tgz",
+          "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ="
         },
         "read": {
           "version": "1.0.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
           "requires": {
             "mute-stream": "0.0.7"
           },
           "dependencies": {
             "mute-stream": {
               "version": "0.0.7",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+              "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
             }
           }
         },
         "read-cmd-shim": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
+          "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
           "requires": {
             "graceful-fs": "4.1.11"
           }
         },
         "read-installed": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+          "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
           "requires": {
             "debuglog": "1.0.1",
             "graceful-fs": "4.1.11",
@@ -14923,13 +15513,15 @@
           "dependencies": {
             "util-extend": {
               "version": "1.0.3",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+              "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
             }
           }
         },
         "read-package-json": {
           "version": "2.0.13",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.13.tgz",
+          "integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
           "requires": {
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
@@ -14940,17 +15532,20 @@
           "dependencies": {
             "json-parse-better-errors": {
               "version": "1.0.1",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+              "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw=="
             },
             "slash": {
               "version": "1.0.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+              "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
             }
           }
         },
         "read-package-tree": {
           "version": "5.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.6.tgz",
+          "integrity": "sha512-FCX1aT3GWyY658wzDICef4p+n0dB+ENRct8E/Qyvppj6xVpOYerBHfUu7OP5Rt1/393Tdglguf5ju5DEX4wZNg==",
           "requires": {
             "debuglog": "1.0.1",
             "dezalgo": "1.0.3",
@@ -14961,7 +15556,8 @@
         },
         "readable-stream": {
           "version": "2.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -14974,32 +15570,38 @@
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
             },
             "process-nextick-args": {
               "version": "2.0.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+              "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
             },
             "string_decoder": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
               "requires": {
                 "safe-buffer": "5.1.1"
               }
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
             }
           }
         },
         "readdir-scoped-modules": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
+          "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
           "requires": {
             "debuglog": "1.0.1",
             "dezalgo": "1.0.3",
@@ -15009,7 +15611,8 @@
         },
         "request": {
           "version": "2.83.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
           "requires": {
             "aws-sign2": "0.7.0",
             "aws4": "1.6.0",
@@ -15037,40 +15640,48 @@
           "dependencies": {
             "aws-sign2": {
               "version": "0.7.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+              "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
             },
             "aws4": {
               "version": "1.6.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+              "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
             },
             "caseless": {
               "version": "0.12.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
             },
             "combined-stream": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
               "requires": {
                 "delayed-stream": "1.0.0"
               },
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
                 }
               }
             },
             "extend": {
               "version": "3.0.1",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+              "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
             },
             "forever-agent": {
               "version": "0.6.1",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
             },
             "form-data": {
               "version": "2.3.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+              "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
               "requires": {
                 "asynckit": "0.4.0",
                 "combined-stream": "1.0.5",
@@ -15079,13 +15690,15 @@
               "dependencies": {
                 "asynckit": {
                   "version": "0.4.0",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                  "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
                 }
               }
             },
             "har-validator": {
               "version": "5.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+              "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
               "requires": {
                 "ajv": "5.2.3",
                 "har-schema": "2.0.0"
@@ -15093,7 +15706,8 @@
               "dependencies": {
                 "ajv": {
                   "version": "5.2.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+                  "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
                   "requires": {
                     "co": "4.6.0",
                     "fast-deep-equal": "1.0.0",
@@ -15103,26 +15717,31 @@
                   "dependencies": {
                     "co": {
                       "version": "4.6.0",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
                     },
                     "fast-deep-equal": {
                       "version": "1.0.0",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+                      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
                     },
                     "json-schema-traverse": {
                       "version": "0.3.1",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+                      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
                     },
                     "json-stable-stringify": {
                       "version": "1.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
                       "requires": {
                         "jsonify": "0.0.0"
                       },
                       "dependencies": {
                         "jsonify": {
                           "version": "0.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
                         }
                       }
                     }
@@ -15130,13 +15749,15 @@
                 },
                 "har-schema": {
                   "version": "2.0.0",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+                  "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
                 }
               }
             },
             "hawk": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+              "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
               "requires": {
                 "boom": "4.3.1",
                 "cryptiles": "3.1.2",
@@ -15146,21 +15767,24 @@
               "dependencies": {
                 "boom": {
                   "version": "4.3.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+                  "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
                   "requires": {
                     "hoek": "4.2.0"
                   }
                 },
                 "cryptiles": {
                   "version": "3.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+                  "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
                   "requires": {
                     "boom": "5.2.0"
                   },
                   "dependencies": {
                     "boom": {
                       "version": "5.2.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+                      "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                       "requires": {
                         "hoek": "4.2.0"
                       }
@@ -15169,11 +15793,13 @@
                 },
                 "hoek": {
                   "version": "4.2.0",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+                  "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
                 },
                 "sntp": {
                   "version": "2.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
+                  "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
                   "requires": {
                     "hoek": "4.2.0"
                   }
@@ -15182,7 +15808,8 @@
             },
             "http-signature": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+              "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
               "requires": {
                 "assert-plus": "1.0.0",
                 "jsprim": "1.4.1",
@@ -15191,11 +15818,13 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                 },
                 "jsprim": {
                   "version": "1.4.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+                  "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
                   "requires": {
                     "assert-plus": "1.0.0",
                     "extsprintf": "1.3.0",
@@ -15205,15 +15834,18 @@
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.3.0",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+                      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
                     },
                     "json-schema": {
                       "version": "0.2.3",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
                     },
                     "verror": {
                       "version": "1.10.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+                      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
                       "requires": {
                         "assert-plus": "1.0.0",
                         "core-util-is": "1.0.2",
@@ -15222,7 +15854,8 @@
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                         }
                       }
                     }
@@ -15230,7 +15863,8 @@
                 },
                 "sshpk": {
                   "version": "1.13.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+                  "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
                   "requires": {
                     "asn1": "0.2.3",
                     "assert-plus": "1.0.0",
@@ -15244,11 +15878,13 @@
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
                     },
                     "bcrypt-pbkdf": {
                       "version": "1.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
                       "optional": true,
                       "requires": {
                         "tweetnacl": "0.14.5"
@@ -15256,14 +15892,16 @@
                     },
                     "dashdash": {
                       "version": "1.14.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                       "requires": {
                         "assert-plus": "1.0.0"
                       }
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                       "optional": true,
                       "requires": {
                         "jsbn": "0.1.1"
@@ -15271,19 +15909,22 @@
                     },
                     "getpass": {
                       "version": "0.1.7",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
                       "requires": {
                         "assert-plus": "1.0.0"
                       }
                     },
                     "jsbn": {
                       "version": "0.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
                       "optional": true
                     },
                     "tweetnacl": {
                       "version": "0.14.5",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
                       "optional": true
                     }
                   }
@@ -15292,61 +15933,73 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
             },
             "isstream": {
               "version": "0.1.2",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
             },
             "mime-types": {
               "version": "2.1.17",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+              "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
               "requires": {
                 "mime-db": "1.30.0"
               },
               "dependencies": {
                 "mime-db": {
                   "version": "1.30.0",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+                  "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
                 }
               }
             },
             "oauth-sign": {
               "version": "0.8.2",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
             },
             "performance-now": {
               "version": "2.1.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+              "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
             },
             "qs": {
               "version": "6.5.1",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+              "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
             },
             "stringstream": {
               "version": "0.0.5",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
             },
             "tough-cookie": {
               "version": "2.3.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+              "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
               "requires": {
                 "punycode": "1.4.1"
               },
               "dependencies": {
                 "punycode": {
                   "version": "1.4.1",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                  "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
                 }
               }
             },
             "tunnel-agent": {
               "version": "0.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+              "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
               "requires": {
                 "safe-buffer": "5.1.1"
               }
@@ -15355,26 +16008,31 @@
         },
         "retry": {
           "version": "0.10.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+          "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "requires": {
             "glob": "7.1.2"
           }
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
         },
         "sha": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
+          "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
           "requires": {
             "graceful-fs": "4.1.11",
             "readable-stream": "2.3.5"
@@ -15382,15 +16040,18 @@
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
         },
         "sorted-object": {
           "version": "2.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
+          "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw="
         },
         "sorted-union-stream": {
           "version": "2.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
+          "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
           "requires": {
             "from2": "1.3.0",
             "stream-iterate": "1.2.0"
@@ -15398,7 +16059,8 @@
           "dependencies": {
             "from2": {
               "version": "1.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
+              "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
               "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "1.1.14"
@@ -15406,7 +16068,8 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                   "requires": {
                     "core-util-is": "1.0.2",
                     "inherits": "2.0.3",
@@ -15416,15 +16079,18 @@
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                     }
                   }
                 }
@@ -15432,7 +16098,8 @@
             },
             "stream-iterate": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
+              "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
               "requires": {
                 "readable-stream": "2.3.5",
                 "stream-shift": "1.0.0"
@@ -15440,7 +16107,8 @@
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                  "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
                 }
               }
             }
@@ -15448,27 +16116,31 @@
         },
         "ssri": {
           "version": "5.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.2.4.tgz",
+          "integrity": "sha512-UnEAgMZa15973iH7cUi0AHjJn1ACDIkaMyZILoqwN6yzt+4P81I8tBc5Hl+qwi5auMplZtPQsHrPBR5vJLcQtQ==",
           "requires": {
             "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
             "ansi-regex": "3.0.0"
           },
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
             }
           }
         },
         "tar": {
           "version": "4.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.0.tgz",
+          "integrity": "sha512-gJlTiiErwo96K904FnoYWl+5+FBgS+FimU6GMh66XLdLa55al8+d4jeDfPoGwSNHdtWI5FJP6xurmVqhBuGJpQ==",
           "requires": {
             "chownr": "1.0.1",
             "fs-minipass": "1.2.5",
@@ -15480,53 +16152,62 @@
           "dependencies": {
             "fs-minipass": {
               "version": "1.2.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+              "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
               "requires": {
                 "minipass": "2.2.1"
               }
             },
             "minipass": {
               "version": "2.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.1.tgz",
+              "integrity": "sha512-u1aUllxPJUI07cOqzR7reGmQxmCqlH88uIIsf6XZFEWgw7gXKpJdR+5R9Y3KEDmWYkdIz9wXZs3C0jOPxejk/Q==",
               "requires": {
                 "yallist": "3.0.2"
               }
             },
             "minizlib": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+              "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
               "requires": {
                 "minipass": "2.2.1"
               }
             },
             "yallist": {
               "version": "3.0.2",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+              "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
             }
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
         },
         "umask": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+          "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0="
         },
         "unique-filename": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+          "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
           "requires": {
             "unique-slug": "2.0.0"
           },
           "dependencies": {
             "unique-slug": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+              "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
               "requires": {
                 "imurmurhash": "0.1.4"
               }
@@ -15535,11 +16216,13 @@
         },
         "unpipe": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
         },
         "update-notifier": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
+          "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
           "requires": {
             "boxen": "1.2.1",
             "chalk": "2.1.0",
@@ -15554,7 +16237,8 @@
           "dependencies": {
             "boxen": {
               "version": "1.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.1.tgz",
+              "integrity": "sha1-DxHn/jRO25OXl3/BPt5/ZNlWSB0=",
               "requires": {
                 "ansi-align": "2.0.0",
                 "camelcase": "4.1.0",
@@ -15567,22 +16251,26 @@
               "dependencies": {
                 "ansi-align": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+                  "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
                   "requires": {
                     "string-width": "2.1.1"
                   }
                 },
                 "camelcase": {
                   "version": "4.1.0",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                  "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
                 },
                 "cli-boxes": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+                  "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
                 },
                 "string-width": {
                   "version": "2.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                  "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                   "requires": {
                     "is-fullwidth-code-point": "2.0.0",
                     "strip-ansi": "4.0.0"
@@ -15590,20 +16278,23 @@
                   "dependencies": {
                     "is-fullwidth-code-point": {
                       "version": "2.0.0",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
                     }
                   }
                 },
                 "term-size": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+                  "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
                   "requires": {
                     "execa": "0.7.0"
                   },
                   "dependencies": {
                     "execa": {
                       "version": "0.7.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+                      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                       "requires": {
                         "cross-spawn": "5.1.0",
                         "get-stream": "3.0.0",
@@ -15616,7 +16307,8 @@
                       "dependencies": {
                         "cross-spawn": {
                           "version": "5.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                           "requires": {
                             "lru-cache": "4.1.1",
                             "shebang-command": "1.2.0",
@@ -15625,14 +16317,16 @@
                           "dependencies": {
                             "shebang-command": {
                               "version": "1.2.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                              "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
                               "requires": {
                                 "shebang-regex": "1.0.0"
                               },
                               "dependencies": {
                                 "shebang-regex": {
                                   "version": "1.0.0",
-                                  "bundled": true
+                                  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                                  "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
                                 }
                               }
                             }
@@ -15640,36 +16334,43 @@
                         },
                         "get-stream": {
                           "version": "3.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
                         },
                         "is-stream": {
                           "version": "1.1.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
                         },
                         "npm-run-path": {
                           "version": "2.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+                          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
                           "requires": {
                             "path-key": "2.0.1"
                           },
                           "dependencies": {
                             "path-key": {
                               "version": "2.0.1",
-                              "bundled": true
+                              "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                              "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
                             }
                           }
                         },
                         "p-finally": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+                          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
                         },
                         "signal-exit": {
                           "version": "3.0.2",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
                         },
                         "strip-eof": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+                          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
                         }
                       }
                     }
@@ -15677,14 +16378,16 @@
                 },
                 "widest-line": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+                  "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
                   "requires": {
                     "string-width": "1.0.2"
                   },
                   "dependencies": {
                     "string-width": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                       "requires": {
                         "code-point-at": "1.1.0",
                         "is-fullwidth-code-point": "1.0.0",
@@ -15693,31 +16396,36 @@
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                           "requires": {
                             "number-is-nan": "1.0.1"
                           },
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
-                              "bundled": true
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                           "requires": {
                             "ansi-regex": "2.1.1"
                           },
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
-                              "bundled": true
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
                             }
                           }
                         }
@@ -15729,7 +16437,8 @@
             },
             "chalk": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+              "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
               "requires": {
                 "ansi-styles": "3.2.0",
                 "escape-string-regexp": "1.0.5",
@@ -15738,21 +16447,24 @@
               "dependencies": {
                 "ansi-styles": {
                   "version": "3.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                  "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                   "requires": {
                     "color-convert": "1.9.0"
                   },
                   "dependencies": {
                     "color-convert": {
                       "version": "1.9.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+                      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
                       "requires": {
                         "color-name": "1.1.3"
                       },
                       "dependencies": {
                         "color-name": {
                           "version": "1.1.3",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
                         }
                       }
                     }
@@ -15760,18 +16472,21 @@
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
                 },
                 "supports-color": {
                   "version": "4.4.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+                  "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                   "requires": {
                     "has-flag": "2.0.0"
                   },
                   "dependencies": {
                     "has-flag": {
                       "version": "2.0.0",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+                      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                     }
                   }
                 }
@@ -15779,7 +16494,8 @@
             },
             "configstore": {
               "version": "3.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
+              "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
               "requires": {
                 "dot-prop": "4.2.0",
                 "graceful-fs": "4.1.11",
@@ -15791,40 +16507,46 @@
               "dependencies": {
                 "dot-prop": {
                   "version": "4.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+                  "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
                   "requires": {
                     "is-obj": "1.0.1"
                   },
                   "dependencies": {
                     "is-obj": {
                       "version": "1.0.1",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+                      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
                     }
                   }
                 },
                 "make-dir": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
+                  "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
                   "requires": {
                     "pify": "2.3.0"
                   },
                   "dependencies": {
                     "pify": {
                       "version": "2.3.0",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
                     }
                   }
                 },
                 "unique-string": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+                  "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
                   "requires": {
                     "crypto-random-string": "1.0.0"
                   },
                   "dependencies": {
                     "crypto-random-string": {
                       "version": "1.0.0",
-                      "bundled": true
+                      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+                      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
                     }
                   }
                 }
@@ -15832,11 +16554,13 @@
             },
             "import-lazy": {
               "version": "2.1.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+              "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
             },
             "is-installed-globally": {
               "version": "0.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+              "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
               "requires": {
                 "global-dirs": "0.1.0",
                 "is-path-inside": "1.0.0"
@@ -15844,14 +16568,16 @@
               "dependencies": {
                 "global-dirs": {
                   "version": "0.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.0.tgz",
+                  "integrity": "sha1-ENNAOeDfBCcuJizyQiT3IJQ0308=",
                   "requires": {
                     "ini": "1.3.5"
                   }
                 },
                 "is-path-inside": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+                  "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
                   "requires": {
                     "path-is-inside": "1.0.2"
                   }
@@ -15860,18 +16586,21 @@
             },
             "is-npm": {
               "version": "1.0.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+              "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
             },
             "latest-version": {
               "version": "3.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+              "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
               "requires": {
                 "package-json": "4.0.1"
               },
               "dependencies": {
                 "package-json": {
                   "version": "4.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+                  "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
                   "requires": {
                     "got": "6.7.1",
                     "registry-auth-token": "3.3.1",
@@ -15881,7 +16610,8 @@
                   "dependencies": {
                     "got": {
                       "version": "6.7.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+                      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
                       "requires": {
                         "create-error-class": "3.0.2",
                         "duplexer3": "0.1.4",
@@ -15898,59 +16628,71 @@
                       "dependencies": {
                         "create-error-class": {
                           "version": "3.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+                          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
                           "requires": {
                             "capture-stack-trace": "1.0.0"
                           },
                           "dependencies": {
                             "capture-stack-trace": {
                               "version": "1.0.0",
-                              "bundled": true
+                              "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+                              "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
                             }
                           }
                         },
                         "duplexer3": {
                           "version": "0.1.4",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+                          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
                         },
                         "get-stream": {
                           "version": "3.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
                         },
                         "is-redirect": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+                          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
                         },
                         "is-retry-allowed": {
                           "version": "1.1.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+                          "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
                         },
                         "is-stream": {
                           "version": "1.1.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
                         },
                         "lowercase-keys": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+                          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
                         },
                         "timed-out": {
                           "version": "4.0.1",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+                          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
                         },
                         "unzip-response": {
                           "version": "2.0.1",
-                          "bundled": true
+                          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+                          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
                         },
                         "url-parse-lax": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+                          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
                           "requires": {
                             "prepend-http": "1.0.4"
                           },
                           "dependencies": {
                             "prepend-http": {
                               "version": "1.0.4",
-                              "bundled": true
+                              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+                              "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
                             }
                           }
                         }
@@ -15958,7 +16700,8 @@
                     },
                     "registry-auth-token": {
                       "version": "3.3.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
+                      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
                       "requires": {
                         "rc": "1.2.1",
                         "safe-buffer": "5.1.1"
@@ -15966,7 +16709,8 @@
                       "dependencies": {
                         "rc": {
                           "version": "1.2.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+                          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
                           "requires": {
                             "deep-extend": "0.4.2",
                             "ini": "1.3.5",
@@ -15976,15 +16720,18 @@
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.2",
-                              "bundled": true
+                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+                              "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
                             },
                             "minimist": {
                               "version": "1.2.0",
-                              "bundled": true
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
                             },
                             "strip-json-comments": {
                               "version": "2.0.1",
-                              "bundled": true
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
                             }
                           }
                         }
@@ -15992,14 +16739,16 @@
                     },
                     "registry-url": {
                       "version": "3.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+                      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
                       "requires": {
                         "rc": "1.2.1"
                       },
                       "dependencies": {
                         "rc": {
                           "version": "1.2.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+                          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
                           "requires": {
                             "deep-extend": "0.4.2",
                             "ini": "1.3.5",
@@ -16009,15 +16758,18 @@
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.2",
-                              "bundled": true
+                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+                              "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
                             },
                             "minimist": {
                               "version": "1.2.0",
-                              "bundled": true
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
                             },
                             "strip-json-comments": {
                               "version": "2.0.1",
-                              "bundled": true
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
                             }
                           }
                         }
@@ -16029,24 +16781,28 @@
             },
             "semver-diff": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+              "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
               "requires": {
                 "semver": "5.5.0"
               }
             },
             "xdg-basedir": {
               "version": "3.0.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+              "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
             }
           }
         },
         "uuid": {
           "version": "3.2.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
           "requires": {
             "spdx-correct": "1.0.2",
             "spdx-expression-parse": "1.0.4"
@@ -16054,52 +16810,60 @@
           "dependencies": {
             "spdx-correct": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
               "requires": {
                 "spdx-license-ids": "1.2.2"
               },
               "dependencies": {
                 "spdx-license-ids": {
                   "version": "1.2.2",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+                  "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
                 }
               }
             },
             "spdx-expression-parse": {
               "version": "1.0.4",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+              "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
             }
           }
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+          "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
           "requires": {
             "builtins": "1.0.3"
           },
           "dependencies": {
             "builtins": {
               "version": "1.0.3",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+              "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
             }
           }
         },
         "which": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "requires": {
             "isexe": "2.0.0"
           },
           "dependencies": {
             "isexe": {
               "version": "2.0.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
             }
           }
         },
         "worker-farm": {
           "version": "1.5.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.4.tgz",
+          "integrity": "sha512-ITyClEvcfv0ozqJl1vmWFWhvI+OIrkbInYqkEPE50wFPXj8J9Gd3FYf8+CkZJXJJsQBYe+2DvmoK9Zhx5w8W+w==",
           "requires": {
             "errno": "0.1.7",
             "xtend": "4.0.1"
@@ -16107,30 +16871,35 @@
           "dependencies": {
             "errno": {
               "version": "0.1.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+              "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
               "requires": {
                 "prr": "1.0.1"
               },
               "dependencies": {
                 "prr": {
                   "version": "1.0.1",
-                  "bundled": true
+                  "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+                  "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
             }
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "write-file-atomic": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+          "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
           "requires": {
             "graceful-fs": "4.1.11",
             "imurmurhash": "0.1.4",
@@ -16139,7 +16908,8 @@
           "dependencies": {
             "signal-exit": {
               "version": "3.0.2",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
             }
           }
         }
@@ -20602,6 +21372,11 @@
             "crypto-js": "3.1.8",
             "utf8": "2.1.2",
             "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+            }
           }
         }
       }
@@ -21346,7 +22121,6 @@
       "version": "0.20.6",
       "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
       "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
-      "dev": true,
       "requires": {
         "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
         "crypto-js": "3.1.8",
@@ -21356,8 +22130,7 @@
       },
       "dependencies": {
         "bignumber.js": {
-          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "dev": true
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
         }
       }
     },
@@ -21635,8 +22408,7 @@
       },
       "dependencies": {
         "bignumber.js": {
-          "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-          "dev": true
+          "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
         },
         "clone": {
           "version": "2.1.2",
@@ -21669,6 +22441,12 @@
             "crypto-js": "3.1.8",
             "utf8": "2.1.2",
             "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+              "dev": true
+            }
           }
         }
       }
@@ -21757,9 +22535,6 @@
           "dev": true
         }
       }
-    },
-    "webcrypto-shim": {
-      "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
     },
     "webpack": {
       "version": "3.4.1",
@@ -22412,8 +23187,7 @@
     "whatwg-fetch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-      "dev": true
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "whet.extend": {
       "version": "0.9.9",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "map-cache": "^0.2.2",
     "npm": "^5.8.0",
     "truffle-contract": "^1.1.8",
-    "util.promisify": "^1.0.0"
+    "util.promisify": "^1.0.0",
+    "web3": "^0.20.6"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
@@ -60,7 +61,6 @@
     "sinon": "^2.4.1",
     "truffle": "^4.1.7",
     "truffle-hdwallet-provider": "0.0.3",
-    "web3": "^0.20.1",
     "webpack": "^3.4.1",
     "webpack-dev-server": "^2.11.2",
     "webpack-node-externals": "^1.6.0"

--- a/src/contract-service.js
+++ b/src/contract-service.js
@@ -5,10 +5,17 @@ import UserRegistryContract from "./../contracts/build/contracts/UserRegistry.js
 import bs58 from "bs58"
 import contract from "truffle-contract"
 import promisify from "util.promisify"
+import Web3 from "web3"
 
 class ContractService {
-  constructor({ web3 } = {}) {
-    this.web3 = web3 || window.web3
+  constructor(options = {}) {
+    const externalWeb3 = options.web3 || window.web3
+    if (!externalWeb3) {
+      throw new Error(
+        "web3 is required for Origin.js. Please pass in web3 as a config option."
+      )
+    }
+    this.web3 = new Web3(externalWeb3.currentProvider)
 
     const contracts = {
       listingsRegistryContract: ListingsRegistryContract,


### PR DESCRIPTION
Currently, origin.js uses whatever web3 is passed in to it. This is bad because different versions of metamask provide different versions of web3 with different APIs, thus breaking our code.

The solution is to use our own bundled version of web3, and route its transactions out through metamask’s web3, or whatever external web3 is provided to origin.js. This way we have a stable internal API. The [metamask FAQ](https://github.com/MetaMask/faq/blob/master/DEVELOPERS.md) recommends doing this: “You can use the injected Web3.js directly, but the best practice is to explicitly bundle the version of web3.js you used during development.”

### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)
- [x] Submit to the `develop` branch instead of `master`