### PR TITLE
🔧Metamask compatible logs

### DIFF
--- a/src/contract-service.js
+++ b/src/contract-service.js
@@ -64,6 +64,32 @@ class ContractService {
     return accounts[0]
   }
 
+  // async convenience method for getting block details
+  getBlock(blockHash) {
+    return new Promise((resolve, reject) => {
+      this.web3.eth.getBlock(blockHash, (error, data) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(data)
+        }
+      })
+    })
+  }
+
+  // async convenience method for getting transaction details
+  getTransaction(transactionHash) {
+    return new Promise((resolve, reject) => {
+      this.web3.eth.getTransaction(transactionHash, (error, data) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(data)
+        }
+      })
+    })
+  }
+
   async submitListing(ipfsListing, ethPrice, units) {
     try {
       const account = await this.currentAccount()

--- a/src/resources/purchases.js
+++ b/src/resources/purchases.js
@@ -52,6 +52,7 @@ class Purchases extends ResourceBase{
   }
 
   async getLogs(address) {
+    const self = this
     const web3 = this.contractService.web3
     const contract = await this.contractDefinition.at(address)
     return new Promise((resolve, reject) => {
@@ -75,10 +76,10 @@ class Purchases extends ResourceBase{
         })
         // Fetch user and timestamp information for all logs, in parallel 
         const addUserAddressFn = async (event)=>{
-          event.from = (await web3.eth.getTransaction(event.transactionHash)).from
+          event.from = (await self.contractService.getTransaction(event.transactionHash)).from
         }
         const addTimestampFn = async (event)=>{
-          event.timestamp = (await web3.eth.getBlock(event.blockHash)).timestamp
+          event.timestamp = (await self.contractService.getBlock(event.blockHash)).timestamp
         }
         const fetchPromises = [].concat(
           logs.map(addUserAddressFn),


### PR DESCRIPTION
Metamask requires us to call web3's getBlock and getTransaction in callback style. The previous versions of this code worked in our testing with web3, both browser and unit tests, but not with Metamask. This PR makes them also work in metamask.

Micah has checked that this works with metamask.

### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)
- [x] Submit to the `develop` branch instead of `master`
