### PR TITLE
Provide origin-js defaults in index

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ var resources = {
 
 const defaultBridgeServer = "https://bridge.originprotocol.com"
 const defaultIpfsDomain = "gateway.originprotocol.com"
-const defaultIpfsApiPort = "443"
+const defaultIpfsApiPort = "5002"
 const defaultIpfsGatewayPort = "443"
 const defaultIpfsGatewayProtocol = "https"
 const defaultAttestationServerUrl = `${defaultBridgeServer}/api/attestations`

--- a/src/index.js
+++ b/src/index.js
@@ -10,13 +10,20 @@ var resources = {
   users: require("./resources/users")
 }
 
+const defaultBridgeServer = "https://bridge.originprotocol.com"
+const defaultIpfsDomain = "gateway.originprotocol.com"
+const defaultIpfsApiPort = "443"
+const defaultIpfsGatewayPort = "443"
+const defaultIpfsGatewayProtocol = "https"
+const defaultAttestationServerUrl = `${defaultBridgeServer}/api/attestations`
+
 class Origin {
   constructor({
-    ipfsDomain,
-    ipfsApiPort,
-    ipfsGatewayPort,
-    ipfsGatewayProtocol,
-    attestationServerUrl,
+    ipfsDomain = defaultIpfsDomain,
+    ipfsApiPort = defaultIpfsApiPort,
+    ipfsGatewayPort = defaultIpfsGatewayPort,
+    ipfsGatewayProtocol = defaultIpfsGatewayProtocol,
+    attestationServerUrl = defaultAttestationServerUrl,
     contractAddresses
   } = {}) {
     this.contractService = new ContractService({ contractAddresses })

--- a/src/ipfs-service.js
+++ b/src/ipfs-service.js
@@ -13,10 +13,10 @@ const Ports = {
 
 class IpfsService {
   constructor({
-    ipfsGatewayProtocol = "https",
-    ipfsDomain = "gateway.originprotocol.com",
-    ipfsGatewayPort = "443",
-    ipfsApiPort = "443"
+    ipfsGatewayProtocol,
+    ipfsDomain,
+    ipfsGatewayPort,
+    ipfsApiPort
   } = {}) {
     this.gateway = `${ipfsGatewayProtocol}://${ipfsDomain}`
     this.api = `${ipfsGatewayProtocol}://${ipfsDomain}`

--- a/test/ipfs-service.test.js
+++ b/test/ipfs-service.test.js
@@ -27,38 +27,6 @@ describe("IpfsService", () => {
     })
   })
 
-  describe("constructor", () => {
-    it("should default to origin", () => {
-      var service = new IpfsService()
-      expect(service.gateway).to.equal("https://gateway.originprotocol.com")
-      expect(service.api).to.equal("https://gateway.originprotocol.com")
-    })
-
-    it("should use specified port if not protocol default", () => {
-      var service = new IpfsService({ ipfsGatewayPort: "8080" })
-      expect(service.gateway).to.equal(
-        "https://gateway.originprotocol.com:8080"
-      )
-
-      service = new IpfsService({
-        ipfsGatewayProtocol: "http",
-        ipfsGatewayPort: "8080"
-      })
-      expect(service.gateway).to.equal("http://gateway.originprotocol.com:8080")
-
-      service = new IpfsService({
-        ipfsGatewayProtocol: "http",
-        ipfsApiPort: "8080"
-      })
-      expect(service.api).to.equal("http://gateway.originprotocol.com:8080")
-    })
-
-    it("should use default protocol port if given port is empty", () => {
-      var service = new IpfsService({ ipfsGatewayPort: "" })
-      expect(service.gateway).to.equal("https://gateway.originprotocol.com")
-    })
-  })
-
   describe("submitFile", () => {
     listings.forEach(({ data, ipfsHash }) => {
       it("should successfully submit file", async () => {


### PR DESCRIPTION
### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)
- [x] Submit to the `develop` branch instead of `master`

### Description:

In origin-js, our defaults should be production values - the idea being that if people use origin-js out of the box without any config, it should be production-ready.

The only change that affects the external API is that we now have a default `attestationServerUrl`. The rest of the changes are just code cleanup (defining everything inside `index`).

Corresponding PR: https://github.com/OriginProtocol/demo-dapp/pull/171
