### PR TITLE
Include identity address in user object

### DIFF
--- a/src/resources/users.js
+++ b/src/resources/users.js
@@ -26,9 +26,10 @@ let validateUser = (data) => {
 }
 
 class UserObject {
-  constructor({ profile, attestations } = {}) {
+  constructor({ profile, attestations, identityAddress } = {}) {
     this.profile = profile
     this.attestations = attestations
+    this.identityAddress = identityAddress
   }
 }
 
@@ -51,6 +52,7 @@ class Users extends ResourceBase {
     let identityAddress = await this.identityAddress(address)
     if (identityAddress) {
       let userData = await this.getClaims(identityAddress)
+      userData.identityAddress = identityAddress
       return new UserObject(userData)
     }
     return new UserObject()


### PR DESCRIPTION
This exposes the identity address of a user in the [user object](http://docs.originprotocol.com/#user-get). This helps to properly satisfy https://github.com/OriginProtocol/demo-dapp/issues/158.

### Checklist:

- [ ] ~Code contains relevant tests for the problem you are solving~
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)
- [x] Submit to the `develop` branch instead of `master`