### PR TITLE
Return wallet address with user

### DIFF
--- a/src/resources/users.js
+++ b/src/resources/users.js
@@ -26,7 +26,8 @@ let validateUser = (data) => {
 }
 
 class UserObject {
-  constructor({ profile, attestations, identityAddress } = {}) {
+  constructor({ address, profile, attestations, identityAddress } = {}) {
+    this.address = address
     this.profile = profile
     this.attestations = attestations
     this.identityAddress = identityAddress
@@ -49,13 +50,14 @@ class Users extends ResourceBase {
   }
 
   async get(address) {
-    let identityAddress = await this.identityAddress(address)
+    const identityAddress = await this.identityAddress(address)
     if (identityAddress) {
-      let userData = await this.getClaims(identityAddress)
-      userData.identityAddress = identityAddress
-      return new UserObject(userData)
+      const userData = await this.getClaims(identityAddress)
+      const obj = Object.assign({}, userData, { address, identityAddress })
+
+      return new UserObject(obj)
     }
-    return new UserObject()
+    return new UserObject({ address })
   }
 
   async identityAddress(address) {


### PR DESCRIPTION
### Checklist:

- [ ] ~Code contains relevant tests for the problem you are solving~
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)
- [x] Submit to the `develop` branch instead of `master`

### Description:

This includes the user's wallet address in the output for a [get](http://docs.originprotocol.com/#user-get) call. This saves the DApp from having to keep track of what address was or was not used to make the request. I also feel like there is some RESTful or otherwise ideological reason for returning a resource's identifier in the response.