### PR TITLE
Receive non-window external web3

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,9 +25,10 @@ class Origin {
     ipfsGatewayPort = defaultIpfsGatewayPort,
     ipfsGatewayProtocol = defaultIpfsGatewayProtocol,
     attestationServerUrl = defaultAttestationServerUrl,
-    contractAddresses
+    contractAddresses,
+    web3
   } = {}) {
-    this.contractService = new ContractService({ contractAddresses })
+    this.contractService = new ContractService({ contractAddresses, web3 })
     this.ipfsService = new IpfsService({
       ipfsDomain,
       ipfsApiPort,


### PR DESCRIPTION
Unless I am mistaken, the `ContractService` constructor expects an external web3 object but, prior to this commit, can only receive it via the window due to a missing optional param from the `Origin` constructor. This change allows for a DApp to supply web3 in browsers that do not have a native wallet nor support MetaMask.