### PR TITLE
Tyleryasaka/listing address support

### DIFF
--- a/contracts/contracts/ListingsRegistry.sol
+++ b/contracts/contracts/ListingsRegistry.sol
@@ -12,7 +12,7 @@ contract ListingsRegistry {
    * Events
    */
 
-  event NewListing(uint _index);
+  event NewListing(uint _index, address _address);
 
   /*
    * Storage
@@ -80,8 +80,9 @@ contract ListingsRegistry {
     public
     returns (uint)
   {
-    listings.push(new Listing(msg.sender, _ipfsHash, _price, _unitsAvailable));
-    emit NewListing(listings.length-1);
+    Listing newListing = new Listing(msg.sender, _ipfsHash, _price, _unitsAvailable);
+    listings.push(newListing);
+    emit NewListing(listings.length-1, address(newListing));
     return listings.length;
   }
 
@@ -101,8 +102,9 @@ contract ListingsRegistry {
     returns (uint)
   {
     require (msg.sender == owner, "Only callable by registry owner");
-    listings.push(new Listing(_creatorAddress, _ipfsHash, _price, _unitsAvailable));
-    emit NewListing(listings.length-1);
+    Listing newListing = new Listing(_creatorAddress, _ipfsHash, _price, _unitsAvailable);
+    listings.push(newListing);
+    emit NewListing(listings.length-1, address(newListing));
     return listings.length;
   }
 }

--- a/src/resources/listings.js
+++ b/src/resources/listings.js
@@ -13,6 +13,18 @@ class Listings extends ResourceBase {
     return await this.contractService.getAllListingIds()
   }
 
+  async allAddresses() {
+    let contract = this.contractService.listingsRegistryContract
+    let deployed = await this.contractService.deployed(contract)
+    let events = await deployed.getPastEvents(
+      "NewListing",
+      { fromBlock: 0, toBlock: "latest" }
+    )
+    return events.map(({ returnValues }) => {
+      return returnValues["_address"]
+    })
+  }
+
   async get(address) {
     const contractData = await this.contractFn(address, "data")
     let ipfsHash = this.contractService.getIpfsHashFromBytes32(contractData[1])

--- a/test/resource_listings.test.js
+++ b/test/resource_listings.test.js
@@ -35,6 +35,12 @@ describe("Listing Resource", function() {
     expect(ids.length).to.be.greaterThan(1)
   })
 
+  it("should get all listing addresses", async () => {
+    await listings.create({ name: "Sample Listing 2", price: 2 }, "")
+    let addresses = await listings.allAddresses()
+    expect(addresses.length).to.be.greaterThan(1)
+  })
+
   it("should get a listing by index", async () => {
     await listings.create({ name: "Foo Bar", price: 1 }, "")
     let listingIds = await contractService.getAllListingIds()


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)
- [x] Submit to the `develop` branch instead of `master`

### Description:

1. Updates our `NewListing` event to include the new listing address.
2. Updates our `listings` resource to have an `allAddresses` method. Same as `allIds`, but with address instead of id

In one day, I ran into 2 separate issues that can be solved with these changes:
- Getting a listing address immediately after creating it. This is needed for clean and easy-to-use jsfiddle demos.
- Getting a list of all our listing addresses. This will allow us to hide listings by address seamlessly. See: https://github.com/OriginProtocol/demo-dapp/pull/222 and https://github.com/OriginProtocol/demo-dapp/issues/221