### PR TITLE
Filter out image URLs that are not `data:` or `dweb:` protocol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17200,8 +17200,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.5.0",
@@ -19889,7 +19888,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.0.tgz",
       "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
-      "dev": true,
       "requires": {
         "querystringify": "^2.0.0",
         "requires-port": "^1.0.0"
@@ -19898,8 +19896,7 @@
         "querystringify": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
-          "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw==",
-          "dev": true
+          "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "form-data": "^2.3.2",
     "map-cache": "^0.2.2",
     "rlp": "^2.0.0",
+    "url-parse": "^1.4.0",
     "web3": "^1.0.0-beta.34"
   },
   "devDependencies": {

--- a/src/resources/listings.js
+++ b/src/resources/listings.js
@@ -2,7 +2,7 @@
 // contractService and ipfsService.
 
 import ResourceBase from "./_resource-base"
-// With Node 10, URL will be availael on top-level object
+// With Node v10, URL will be available on top-level object
 import URL from "url-parse"
 
 class Listings extends ResourceBase {

--- a/test/resource_listings.test.js
+++ b/test/resource_listings.test.js
@@ -72,11 +72,10 @@ describe("Listing Resource", function() {
 
   it("should create a listing", async () => {
     const listingData = {
-      name: "1972 Geo Metro 255K",
+      name: "1992 Geo Metro 255K",
       category: "Cars & Trucks",
       location: "New York City",
-      description:
-        "The American auto-show highlight reel will be disproportionately concentrated on the happenings in New York.",
+      description: "An amazing automobile.",
       pictures: undefined,
       price: 3.3
     }
@@ -100,6 +99,36 @@ describe("Listing Resource", function() {
 
     const listingAfter = await listings.getByIndex(listingIndex)
     expect(listingAfter.unitsAvailable).to.equal(0)
+  })
+
+  it("should only allow data: and dweb: uris for images", async () => {
+    const listingData = {
+      name: "1992 Geo Metro 255K",
+      category: "Cars & Trucks",
+      location: "New York City",
+      description: "An amazing automobile.",
+      pictures: [
+        "https://upload.wikimedia.org/wikipedia/commons/4/40/97_Geo_Metro.jpg",
+        "dweb:/ipfs/QmSZ3QjZc7ubrfMFLMAUiUkJHfZ4WUEPop5dLkoVX3ewA5",
+        "data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7",
+        "garbage",
+        42
+      ],
+      price: 3.3
+    }
+    const validPicturees = [
+      "dweb:/ipfs/QmSZ3QjZc7ubrfMFLMAUiUkJHfZ4WUEPop5dLkoVX3ewA5",
+      "data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7"
+    ]
+    const schema = "for-sale"
+    await listings.create(listingData, schema)
+
+    const listingIds = await contractService.getAllListingIds()
+    const listing = await listings.getByIndex(listingIds[listingIds.length - 1])
+
+    expect(JSON.stringify(listing.pictures)).to.equal(
+      JSON.stringify(validPicturees)
+    )
   })
 
   describe("Getting purchase addresses", async () => {


### PR DESCRIPTION
### Checklist:

- [X] Code contains relevant tests for the problem you are solving
- [X] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)
- [X] Submit to the `develop` branch instead of `master`

## Description:

### Description of the problem being solved

Filter out image URLs that are not `data:` or `dweb:` protocol. This is first step to linking to image IPFS hashes in our Listing json. 

Currently we filter out non-`data:` URLs in the Dapp. 

I think origin-js is the right place to filter, though an argument could be made that DApp developers should be free to take on risks of accepting URLs with unsafe protocols (eg `http`)

Next steps would be:
- Remove URL checks in DApp
- Change listing submission code to upload images first, then link to them in listing json with links like  `dweb:/ipfs/QmWP28bNAJbkiKrXHAHzotKCvLyNragErycSYQQR9KiFby`
