### PR TITLE
Disallow purchase of listing by its seller

### DIFF
--- a/contracts/contracts/Listing.sol
+++ b/contracts/contracts/Listing.sol
@@ -59,6 +59,11 @@ contract Listing {
     _;
   }
 
+  modifier isNotSeller() {
+    require(msg.sender != owner);
+    _;
+  }
+
   /*
     * Public functions
     */
@@ -76,6 +81,7 @@ contract Listing {
   function buyListing(uint _unitsToBuy)
     public
     payable
+    isNotSeller
   {
     // Ensure that this is not trying to purchase more than is available.
     require(_unitsToBuy <= unitsAvailable);

--- a/contracts/test/TestPurchase.js
+++ b/contracts/test/TestPurchase.js
@@ -421,4 +421,19 @@ contract("Purchase", accounts => {
       assert.equal((await purchase.stage()).toNumber(), BUYER_PENDING)
     })
   })
+
+  it("should not allow purchase of listing by its seller", async () => {
+    listing = await Listing.new(seller, ipfsHash, totalPrice, unitsAvailable, {
+      from: seller
+    })
+    try {
+      await listing.buyListing(1, {
+        from: seller,
+        value: totalPrice
+      })
+      assert.ok(false, "allowed a seller to purchase their own listing")
+    } catch (err) {
+      assert.ok(isEVMError(err), "an EVM error should be thrown")
+    }
+  })
 })

--- a/test/resource_listings.test.js
+++ b/test/resource_listings.test.js
@@ -11,6 +11,7 @@ describe("Listing Resource", function() {
   var contractService
   var ipfsService
   var testListingIds
+  var buyer
 
   before(async () => {
     let provider = new Web3.providers.HttpProvider("http://localhost:8545")
@@ -24,6 +25,8 @@ describe("Listing Resource", function() {
     })
     listings = new Listings({ contractService, ipfsService })
     testListingIds = await contractService.getAllListingIds()
+    const accounts = await web3.eth.getAccounts()
+    buyer = accounts[1]
 
     // Ensure that there are at least 2 sample listings
     await listings.create({ name: "Sample Listing 1", price: 1 }, "")
@@ -63,11 +66,9 @@ describe("Listing Resource", function() {
     await listings.create({ name: "My Listing", price: 1 }, "")
     let listingIds = await contractService.getAllListingIds()
     const listing = await listings.getByIndex(listingIds[listingIds.length - 1])
-    const transaction = await listings.buy(
-      listing.address,
-      1,
-      listing.price * 1
-    )
+    const transaction = await contractService.asAccount(buyer, async () => {
+      await listings.buy(listing.address, 1, listing.price * 1)
+    })
   })
 
   it("should create a listing", async () => {
@@ -108,7 +109,9 @@ describe("Listing Resource", function() {
       await listings.create({ name: "My Listing", price: 1 }, "")
       const listingIds = await contractService.getAllListingIds()
       listing = await listings.getByIndex(listingIds[listingIds.length - 1])
-      const transaction = await listings.buy(listing.address, 1, 1)
+      await contractService.asAccount(buyer, async () => {
+        const transaction = await listings.buy(listing.address, 1, 1)
+      })
     })
 
     it("should get the number of purchases", async () => {

--- a/test/resource_purchases.test.js
+++ b/test/resource_purchases.test.js
@@ -18,6 +18,7 @@ describe("Purchase Resource", function() {
   var ipfsService
   var testListingIds
   var web3
+  var buyer
 
   before(async () => {
     let provider = new Web3.providers.HttpProvider("http://localhost:8545")
@@ -32,6 +33,8 @@ describe("Purchase Resource", function() {
     listings = new Listings({ contractService, ipfsService })
     purchases = new Purchase({ contractService, ipfsService })
     reviews = new Review({ contractService, ipfsService })
+    const accounts = await web3.eth.getAccounts()
+    buyer = accounts[1]
   })
 
   // Helpers
@@ -55,10 +58,11 @@ describe("Purchase Resource", function() {
     listing = await listings.getByIndex(listingEvent.returnValues._index)
 
     // Buy listing to create a purchase
-    const purchaseTransaction = await listings.buy(
-      listing.address,
-      1,
-      listing.price - 0.1
+    const purchaseTransaction = await contractService.asAccount(
+      buyer,
+      async () => {
+        return await listings.buy(listing.address, 1, listing.price - 0.1)
+      }
     )
     const purchaseEvent = purchaseTransaction.events.ListingPurchased
     purchase = await purchases.get(purchaseEvent.returnValues._purchaseContract)
@@ -79,17 +83,17 @@ describe("Purchase Resource", function() {
     it("should get a purchase", async () => {
       expectStage("awaiting_payment")
       expect(purchase.listingAddress).to.equal(listing.address)
-      expect(purchase.buyerAddress).to.equal(
-        await contractService.currentAccount()
-      )
+      expect(purchase.buyerAddress).to.equal(buyer)
     })
 
     it("should allow the buyer to pay", async () => {
       expectStage("awaiting_payment")
-      await purchases.pay(
-        purchase.address,
-        contractService.web3.utils.toWei("0.1", "ether")
-      )
+      await contractService.asAccount(buyer, async () => {
+        await purchases.pay(
+          purchase.address,
+          contractService.web3.utils.toWei("0.1", "ether")
+        )
+      })
       purchase = await purchases.get(purchase.address)
       expectStage("shipping_pending")
     })
@@ -103,7 +107,9 @@ describe("Purchase Resource", function() {
 
     it("should allow the buyer to mark a purchase received", async () => {
       expectStage("buyer_pending")
-      await purchases.buyerConfirmReceipt(purchase.address, { rating: 3 })
+      await contractService.asAccount(buyer, async () => {
+        await purchases.buyerConfirmReceipt(purchase.address, { rating: 3 })
+      })
       purchase = await purchases.get(purchase.address)
       expectStage("seller_pending")
     })


### PR DESCRIPTION
### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)
- [x] Submit to the `develop` branch instead of `master`

### Description:

* Remove purchasing account's own listings in tests
  * This is a prerequisite for the following change
* Forbid sellers from purchasing their own listing

As is probably obvious, I'm inexperienced with modern JS, so pointers on how I can be more idiomatic and other tips would be appreciated.