### PR TITLE
Disallow purchase of listing by its seller + test helper

### DIFF
--- a/contracts/contracts/Listing.sol
+++ b/contracts/contracts/Listing.sol
@@ -59,6 +59,11 @@ contract Listing {
     _;
   }
 
+  modifier isNotSeller() {
+    require(msg.sender != owner);
+    _;
+  }
+
   /*
     * Public functions
     */
@@ -76,6 +81,7 @@ contract Listing {
   function buyListing(uint _unitsToBuy)
     public
     payable
+    isNotSeller
   {
     // Ensure that this is not trying to purchase more than is available.
     require(_unitsToBuy <= unitsAvailable);

--- a/contracts/test/TestPurchase.js
+++ b/contracts/test/TestPurchase.js
@@ -421,4 +421,19 @@ contract("Purchase", accounts => {
       assert.equal((await purchase.stage()).toNumber(), BUYER_PENDING)
     })
   })
+
+  it("should not allow purchase of listing by its seller", async () => {
+    listing = await Listing.new(seller, ipfsHash, totalPrice, unitsAvailable, {
+      from: seller
+    })
+    try {
+      await listing.buyListing(1, {
+        from: seller,
+        value: totalPrice
+      })
+      assert.ok(false, "allowed a seller to purchase their own listing")
+    } catch (err) {
+      assert.ok(isEVMError(err), "an EVM error should be thrown")
+    }
+  })
 })

--- a/src/services/contract-service.js
+++ b/src/services/contract-service.js
@@ -75,7 +75,7 @@ class ContractService {
   }
 
   // Returns the first account listed, unless a default account has been set
-  // expcicitly
+  // explicitly
   async currentAccount() {
     const accounts = await this.web3.eth.getAccounts()
     const defaultAccount = this.web3.eth.defaultAccount

--- a/src/services/contract-service.js
+++ b/src/services/contract-service.js
@@ -74,10 +74,12 @@ class ContractService {
     return hashStr
   }
 
-  // Returns the first account listed
+  // Returns the first account listed, unless a default account has been set
+  // expcicitly
   async currentAccount() {
     const accounts = await this.web3.eth.getAccounts()
-    return accounts[0]
+    const defaultAccount = this.web3.eth.defaultAccount
+    return defaultAccount || accounts[0]
   }
 
   // async convenience method for getting block details

--- a/test/helpers/as-account.js
+++ b/test/helpers/as-account.js
@@ -1,0 +1,8 @@
+export default async function asAccount(web3, account, fn) {
+  const accounts = await web3.eth.getAccounts()
+  const accountBefore = web3.eth.defaultAccount || accounts[0]
+  web3.eth.defaultAccount = account
+  const result = await fn()
+  web3.eth.defaultAccount = accountBefore
+  return result
+}


### PR DESCRIPTION
### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)
- [x] Submit to the `develop` branch instead of `master`

### Description:

I branched off of https://github.com/OriginProtocol/origin-js/pull/221 and implemented an alternate solution for executing test calls in the context of a specific active account.

This approach is inspired by @cuongdo 's approach and is quite similar, but I prefer this approach because it uses a built-in web3 property `eth.defaultAccount` (that we should probably be using anyways), rather than adding our own property for monkey-patching the current account during tests. It also places all the responsibility of reseting the active account in the test helper, keeping the test code clean and easier to maintain.

Closes #213 