### PR TITLE
avoid re-execution of calls through approve endpoint

### DIFF
--- a/contracts/contracts/identity/KeyHolderLibrary.sol
+++ b/contracts/contracts/identity/KeyHolderLibrary.sol
@@ -93,6 +93,7 @@ library KeyHolderLibrary {
       returns (bool success)
   {
       require(keyHasPurpose(_keyHolderData, keccak256(msg.sender), 2), "Sender does not have action key");
+      require(!_keyHolderData.executions[_id].executed, "Already executed");
 
       emit Approved(_id, _approve);
 


### PR DESCRIPTION
The *approve* endpoint does not perform any check on the executed status of the call, as opposed to the *execute* endpoint. This change blocks an user being able to re-execute previous calls using the *approve* endpoint.