### PR TITLE
Remove param name to silence unused param warning

### DIFF
--- a/contracts/contracts/FractionalListing.sol
+++ b/contracts/contracts/FractionalListing.sol
@@ -41,7 +41,7 @@ contract FractionalListing is Listing {
     * Public functions
   */
 
-  function isApproved(Purchase _purchase)
+  function isApproved(Purchase)
     public
     view
     returns (bool)


### PR DESCRIPTION
### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)
- [x] Submit to the `develop` branch instead of `master`

### Description:

Removes the warning: `Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.`

The parameter is unused because it is defined on the base contract; one of the inherited contracts uses the param, but the other does not.