### PR TITLE
Enable retrieval of all purchases from indexing server

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,9 @@ class Origin {
 
     this.purchases = new Purchases({
       contractService: this.contractService,
-      ipfsService: this.ipfsService
+      ipfsService: this.ipfsService,
+      indexingServerUrl,
+      fetch
     })
 
     this.notifications = new Notifications({

--- a/src/resources/listings.js
+++ b/src/resources/listings.js
@@ -52,7 +52,7 @@ class Listings extends ResourceBase {
       listingsLength = await instance.methods.listingsLength().call()
     } catch (error) {
       console.log(error)
-      console.log("Can't get number of listings.")
+      console.log('Cannot get number of listings')
       throw error
     }
 

--- a/src/resources/purchases.js
+++ b/src/resources/purchases.js
@@ -1,5 +1,9 @@
 import ResourceBase from './_resource-base'
 
+const appendSlash = url => {
+  return url.substr(-1) === '/' ? url : url + '/'
+}
+
 const _STAGES_TO_NUMBER = {
   awaiting_payment: 0,
   awaiting_seller_approval: 1,
@@ -17,14 +21,27 @@ const EMPTY_IPFS =
   '0x0000000000000000000000000000000000000000000000000000000000000000'
 
 class Purchases extends ResourceBase {
-  constructor({ contractService, ipfsService }) {
+  constructor({ contractService, ipfsService, fetch, indexingServerUrl }) {
     super({ contractService, ipfsService })
 
     this.contractDefinition = this.contractService.purchaseContract
+    this.fetch = fetch
+    this.indexingServerUrl = indexingServerUrl
 
     Object.entries(_STAGES_TO_NUMBER).forEach(([k, v]) => {
       _NUMBERS_TO_STAGE[v] = k
     })
+  }
+
+  // fetches all purchases (all data included)
+  async all() {
+    try {
+      return await this.allIndexed()
+    } catch (error) {
+      console.error(error)
+      console.log('Cannot get all purchases')
+      throw error
+    }
   }
 
   async get(address) {
@@ -127,6 +144,26 @@ class Purchases extends ResourceBase {
             .catch(error => reject(error))
         }
       )
+    })
+  }
+
+  /*
+      private
+  */
+
+  async allIndexed() {
+    const url = appendSlash(this.indexingServerUrl) + 'purchase'
+    const response = await this.fetch(url, { method: 'GET' })
+    const json = await response.json()
+    return json.objects.map(obj => {
+      return {
+        address: obj['contract_address'],
+        buyerAddress: obj['buyer_address'],
+        buyerTimeout: obj['buyer_timeout'],
+        created: obj['created_at'],
+        listingAddress: obj['listing_address'],
+        stage: obj['stage']
+      }
     })
   }
 }

--- a/src/resources/purchases.js
+++ b/src/resources/purchases.js
@@ -159,8 +159,9 @@ class Purchases extends ResourceBase {
       return {
         address: obj['contract_address'],
         buyerAddress: obj['buyer_address'],
-        buyerTimeout: obj['buyer_timeout'],
-        created: obj['created_at'],
+        // https://github.com/OriginProtocol/origin-bridge/issues/102
+        buyerTimeout: +new Date(obj['buyer_timeout']),
+        created: +new Date(obj['created_at']),
         listingAddress: obj['listing_address'],
         stage: obj['stage']
       }


### PR DESCRIPTION
### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [x] Submit to the `develop` branch instead of `master`

### Description:

This resolves #266. Pagination will be a separate issue, and I held off on adding a `noIndex` option because it would require significant changes to the smart contract that I'm not sure we want to add. I think it makes more sense to let consumers retrieve all purchases **_per listing_** as we currently do in the DApp.