### PR TITLE
Add pictures to indexed data

### DIFF
--- a/src/resources/listings.js
+++ b/src/resources/listings.js
@@ -263,8 +263,12 @@ class Listings extends ResourceBase {
     const url = appendSlash(this.indexingServerUrl) + 'listing'
     const response = await this.fetch(url, { method: 'GET' })
     const json = await response.json()
-    return json.objects.map(obj => {
+    return Promise.all(json.objects.map(async obj => {
       const ipfsData = obj['ipfs_data']
+      // While we wait on https://github.com/OriginProtocol/origin-bridge/issues/18
+      // we fetch the array of image data strings for each listing
+      const indexedIpfsData = await this.ipfsService.getFile(obj['ipfs_hash'])
+      const pictures = indexedIpfsData.data.pictures
       return {
         address: obj['contract_address'],
         ipfsHash: obj['ipfs_hash'],
@@ -278,9 +282,9 @@ class Listings extends ResourceBase {
         category: ipfsData ? ipfsData['category'] : null,
         description: ipfsData ? ipfsData['description'] : null,
         location: ipfsData ? ipfsData['location'] : null,
-        pictures: ipfsData ? ipfsData['pictures'] : null
+        pictures
       }
-    })
+    }))
   }
 }
 


### PR DESCRIPTION
### Checklist:

- [x] Ensure all new and existing tests pass
- [x] Submit to the `develop` branch instead of `master`

### Description:

This provides a temporary fix for getting IPFS image data that is not being indexed by the bridge server. By doing this, we negate the performance gains of using the indexing service vs querying the blockchain, but the performance shouldn't be any worse than it was before the bridge server integration. And this allows us to prove the concept of the indexing service, which will be much more performant after https://github.com/OriginProtocol/origin-bridge/issues/18 is resolved.
