### PR TITLE
Add ability to run single contract test

### DIFF
--- a/scripts/helpers/test-contracts.js
+++ b/scripts/helpers/test-contracts.js
@@ -1,10 +1,22 @@
 const { spawn } = require('child_process')
 
+// When run with no arguments, this script runs all contract tests. It
+// optionally takes a single argument that specifies the path of a single
+// contract test to run. That path is relative to 'contracts/test'.
 const testContracts = () => {
   return new Promise((resolve, reject) => {
+    const testFile = process.argv[2]
+    let truffleArgs
+    if (testFile === undefined) {
+      truffleArgs = ['test', '--compile-all']
+    }
+    else {
+      console.log('running ' + testFile)
+      truffleArgs = ['test', 'test/'+testFile, '--compile-all']
+    }
     const truffleTest = spawn(
       '../node_modules/.bin/truffle',
-      ['test', '--compile-all'],
+      truffleArgs,
       { cwd: './contracts' }
     )
     truffleTest.stdout.pipe(process.stdout)


### PR DESCRIPTION
### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)
- [x] Submit to the `develop` branch instead of `master`

### Description:

Helps reduce iteration time for new tests.

`npm run test:contracts`
    still runs all contract tests

`npm run test:contracts -- TestListingsRegistryStorage.js`
    runs just contracts/test/TestListingsRegistryStorage.js

Couldn't easily support multiple test files -- `truffle test` only supports specifying at most 1 test file!