### PR TITLE
Tweak the methods

### DIFF
--- a/src/resources/messaging.js
+++ b/src/resources/messaging.js
@@ -122,6 +122,7 @@ class Messaging extends ResourceBase {
     this.convs = {}
     this.ecies = ecies
     this.events = new EventEmitter()
+    this.unreadStatus = UNREAD_STATUS
   }
 
   onAccount(account_key) {
@@ -665,21 +666,25 @@ class Messaging extends ResourceBase {
     }
   }
 
-  canReceiveMessages(remote_eth_address) {
+  canConverseWith(remote_eth_address) {
     const { account_key, global_keys } = this
 
-    return remote_eth_address !== account_key &&
-           global_keys &&
+    return this.canSendMessages() &&
+           account_key !== remote_eth_address &&
+           global_keys && global_keys.get(remote_eth_address)
+  }
+
+  canReceiveMessages(remote_eth_address) {
+    const { global_keys } = this
+
+    return global_keys &&
            global_keys.get(remote_eth_address)
   }
 
-  canSendMessages(remote_eth_address) {
-    const { account, account_key, global_keys } = this
+  canSendMessages() {
+    const { account, account_key } = this
 
-    return account &&
-           account_key &&
-           account_key !== remote_eth_address &&
-           global_keys && (!remote_eth_address || global_keys.get(remote_eth_address))
+    return account && account_key
   }
 
   async startConv(remote_eth_address) {


### PR DESCRIPTION
I think I tried to be too cute in the prior PR.

Now I explicitly answer...
- can I converse with this user?
- can this user receive messages?
- can I send messages at all? (in case I missed the `onAccount` event)

In the previous `canSendMessages`, it answered "can I send messages _to this user_ if I pass in an argument OR "can I send messages _at all_ if no argument. This was poor design and failed work as expected if the passed in argument was `undefined`.

This also exposes the unread status string for use by the DApp without hard-coding it there. This should be everything that we need to support the welcome message that I will PR tomorrow.