### PR TITLE
Get package.json version number from an origin.js instance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ const defaultIpfsGatewayPort = '443'
 const defaultIpfsGatewayProtocol = 'https'
 const defaultAttestationServerUrl = `${defaultBridgeServer}/api/attestations`
 const defaultIndexingServerUrl = `${defaultBridgeServer}/api`
+const VERSION = require('.././package.json').version
 
 class Origin {
   constructor({
@@ -34,6 +35,8 @@ class Origin {
     ecies,
     messagingNamespace
   } = {}) {
+    this.version = VERSION
+
     this.contractService = new ContractService({ contractAddresses, web3 })
     this.ipfsService = new IpfsService({
       ipfsDomain,


### PR DESCRIPTION
`origin.version` now gives you the npm/package.json version number.

Closes https://github.com/OriginProtocol/origin-dapp/issues/399