### PR TITLE
Listener - Continue where it left off after a restart

### DIFF
--- a/daemon/indexing/listener/README.md
+++ b/daemon/indexing/listener/README.md
@@ -8,7 +8,7 @@ The listener will let you know one or more times about an event. Make sure your 
 
 To allow the listener to be compatible with [infura.io](https://infura.io/), it does not use subscriptions, only API queries.
 
-## Running
+# Running
 
 First you'll need a blockchain network to listen to. To get a local network work, you can start up the origin box, or you can run `npm start run` from the origin.js directory.
 
@@ -16,7 +16,9 @@ A simple way to see the listener in action:
 
     node scripts/listener.js --verbose
 
-### Command line options
+## Command line options
+
+Output:
 
 `--verbose` Output json for all event information to stdout
 
@@ -26,8 +28,12 @@ A simple way to see the listener in action:
 
 `--db` Experimental support for recording listings directly into postgres (see instructions for setting up the db [here](../README.md))
 
+Events:
 
-## How the listener works
+`--continue-file=path` Will start following events at the block number defined in the file, and will keep this file updated as it listens to events.
+
+
+# How the listener works
 
 The listener checks every few seconds for a new block number. If it sees one, it requests all origin related events from the last block it saw an event on, to the new block.
 

--- a/daemon/indexing/listener/listener.js
+++ b/daemon/indexing/listener/listener.js
@@ -1,3 +1,4 @@
+const fs = require('fs')
 const http = require('http')
 const urllib = require('url')
 const Web3 = require('web3')
@@ -10,10 +11,11 @@ const db = require('../lib//db.js')
 // ---------------
 
 // Todo
-// - Allow configuring web3 endpoint and IPFS endpoint
-// - Persist starting point
+// - Allow configuring web3 endpoint, network, and IPFS endpoint
 // - Handle blockchain splits/winners
+// - Possibly switch lastLogBlock to be closer to last found block
 // - Include current-as-of block numbers in POSTs
+// - Persist starting point in DB
 // - Perhaps send related data as it was at the time of the event, not crawl time
 
 const web3Provider = new Web3.providers.HttpProvider('http://localhost:8545')
@@ -104,7 +106,7 @@ const LISTEN_RULES = {
 async function liveTracking(config) {
   const context = await new Context(config).init()
 
-  let lastLogBlock = 0
+  let lastLogBlock = getLastBlock(config)
   let lastCheckedBlock = 0
   const checkIntervalSeconds = 5
   let start
@@ -122,6 +124,7 @@ async function liveTracking(config) {
       const batchLastLogBlock = await runBatch(opts, context)
       if (batchLastLogBlock != undefined) {
         lastLogBlock = batchLastLogBlock
+        setLastBlock(config, lastLogBlock)
       }
       lastCheckedBlock = currentBlockNumber
       return scheduleNextCheck()
@@ -134,6 +137,26 @@ async function liveTracking(config) {
   }
 
   check()
+}
+
+function getLastBlock(config){
+  if(config.continueFile == undefined || !fs.existsSync(config.continueFile)){
+    return 0
+  }
+  const json = fs.readFileSync(config.continueFile, {encoding:"utf8"})
+  const data = JSON.parse(json)
+  if(data.lastLogBlock){
+    return data.lastLogBlock
+  }
+  return 0
+}
+
+function setLastBlock(config, blockNumber){
+  if(config.continueFile == undefined){
+    return
+  }
+  const json = JSON.stringify({lastLogBlock: blockNumber, version:1})
+  fs.writeFileSync(config.continueFile, json, {encoding: "utf8"})
 }
 
 // runBatch - gets and processes logs for a range of blocks
@@ -402,6 +425,8 @@ const config = {
   // Index events in the database.
   db: args['--db'],
   // Verbose mode, includes dumping events on the console.
-  verbose: args['--verbose']
+  verbose: args['--verbose'],
+  // File to use for picking which block number to restart from
+  continueFile: args['--continue-file']
 }
 liveTracking(config)


### PR DESCRIPTION
`--continue-file=path` - Will start following events at the block number defined in the file, and will keep this file updated as it listens to events.

This should be merged after PR #357 to keep the history simple.