### PR TITLE
Include our contract addresses in origin.js

### DIFF
--- a/contracts/releases/addresses.json
+++ b/contracts/releases/addresses.json
@@ -1,0 +1,26 @@
+{
+  "listingsRegistryContract": {
+    "networks": {
+      "3": { "address": "0x67057a6ddbc10d1c75a8812f770854f8627fc7b6" },
+      "4": { "address": "0x4f041f3ec338f85048831d1dff15433d3cb3983f" }
+    }
+  },
+  "listingsRegistryStorageContract": {
+    "networks": {
+      "3": { "address": "0x2293f5592885de85c68b03f69522023957ad5133" },
+      "4": { "address": "0x12593d9f73d8cc7056dc073617380694e92d3a49" }
+    }
+  },
+  "userRegistryContract": {
+    "networks": {
+      "3": { "address": "0xd9ed0df63df8dbe53ef108de9b3c59ad0118912c" },
+      "4": { "address": "0xa080e08a6355debebbc29b9e35d8c001ad6eb3cd" }
+    }
+  },
+  "originIdentityContract": {
+    "networks": {
+      "3": { "address": "0x788371f0976b370f435ef45303f8f7f14ee27e15" },
+      "4": { "address": "0xc8467dc9155f9d7045ea478c85dc074aecb893c6" }
+    }
+  }
+}

--- a/src/services/contract-service.js
+++ b/src/services/contract-service.js
@@ -5,9 +5,10 @@ import KeyHolderLibrary from './../../contracts/build/contracts/KeyHolderLibrary
 import UserRegistryContract from './../../contracts/build/contracts/UserRegistry.json'
 import OriginIdentityContract from './../../contracts/build/contracts/OriginIdentity.json'
 import OriginTokenContract from './../../contracts/build/contracts/OriginToken.json'
-
 import V00_MarketplaceContract from './../../contracts/build/contracts/V00_Marketplace.json'
 import V01_MarketplaceContract from './../../contracts/build/contracts/V01_Marketplace.json'
+
+import ContractAddresses from './../../contracts/releases/addresses.json'
 
 import bs58 from 'bs58'
 import Web3 from 'web3'
@@ -44,7 +45,8 @@ class ContractService {
         this[name].networks = Object.assign(
           {},
           this[name].networks,
-          options.contractAddresses[name]
+          ((ContractAddresses[name]|{}).network|{}),
+          (options.contractAddresses[name]|{})
         )
       } catch (e) {
         /* Ignore */

--- a/src/services/contract-service.js
+++ b/src/services/contract-service.js
@@ -44,9 +44,9 @@ class ContractService {
       try {
         this[name].networks = Object.assign(
           {},
-          ((ContractAddresses[name]|{}).network|{}), // start with hard coded addresses
+          ((ContractAddresses[name]||{}).network||{}), // start with hard coded addresses
           this[name].networks, // override with addresses in contracts/build
-          (options.contractAddresses[name]|{}) // override with passed in options
+          (options.contractAddresses[name]||{}) // override with passed in options
         )
       } catch (e) {
         /* Ignore */

--- a/src/services/contract-service.js
+++ b/src/services/contract-service.js
@@ -44,9 +44,9 @@ class ContractService {
       try {
         this[name].networks = Object.assign(
           {},
-          this[name].networks,
-          ((ContractAddresses[name]|{}).network|{}),
-          (options.contractAddresses[name]|{})
+          ((ContractAddresses[name]|{}).network|{}), // start with hard coded addresses
+          this[name].networks, // override with addresses in contracts/build
+          (options.contractAddresses[name]|{}) // override with passed in options
         )
       } catch (e) {
         /* Ignore */


### PR DESCRIPTION
Currently our non-local contract addresses only live in contracts/build json files and are not in version control and cannot be used outside of NPM releases.

This PR creates an addresses.json file that holds all our official contract addresses. These addresses are automatically injected into our contracts definitions.

Advantages:

- Clear at all times what our official contract addresses are
- Version control for our contract addresses
- You can work on the public networks from git versions of origin.js

Addresses used:

I've used the current contract addresses used in https://demo.originprotocol.com/
