### PR TITLE
📙 Discovery - switch connections to using “nodes”

### DIFF
--- a/daemon/indexing/apollo/index.js
+++ b/daemon/indexing/apollo/index.js
@@ -94,7 +94,7 @@ const typeDefs = gql`
     num: Int!
     size: Int!
     total: Int!
-    listings: [Listing]
+    nodes: [Listing]
   }
 
   ######################
@@ -210,7 +210,7 @@ const resolvers = {
         num: 1,
         size: listings.length,
         total: 1,
-        listings: listings,
+        nodes: listings,
       }
     },
     listing(root, args, context, info) {


### PR DESCRIPTION
I like github/facebook's schema's style better, using just "nodes" for the actual object list. I think it's easier to read when compared with aways duplicating the name of the thing we are accessing.

    listings{nodes{id}} <-- new
      vs.
    listings{listings{id}}  <-- old

Plus it's a little more standard.

@sparrowDom (This change will affect you)
