### PR TITLE
npm targets `test:js` and `test:jsw`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,21 @@ npm run test
 
  Note: you should *not* have the server running at this time, as these tests start their own local blockchain instance.
 
- ### Command Line (Only Solidity Tests)
+### Command Line (Non-Solidity Tests)
+
+To run non-contract tests (`test/**.js`):
+
+```
+npm run test:js
+```
+
+To run non-contract tests and automatically re-run when files change:
+```
+npm run test:jsw
+```
+
+
+### Command Line (Only Solidity Tests)
 
 Our Solidity tests (which use [Truffle](http://truffleframework.com/docs/getting_started/javascript-tests)) are located at `contracts/test`.
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "start:no-ganache": "node scripts/build.js serve no-ganache",
     "test": "node scripts/test.js",
     "test:truffle": "node scripts/test-truffle.js",
-    "test:js": "mocha --compilers js:babel-core/register --require babel-polyfill",
+    "test:js": "node scripts/test-js.js",
+    "test:jsw": "node scripts/test-js.js --watch",
     "test:contracts": "mocha -r babel-register -r babel-polyfill -t 10000 --exit contracts/test-alt/",
     "test:contractsw": "mocha -r babel-register -r babel-polyfill -t 10000 -w --watch-extensions sol contracts/test-alt/",
     "test:contracts-coverage": "SOLIDITY_COVERAGE=1 npx solidity-coverage"

--- a/scripts/test-js.js
+++ b/scripts/test-js.js
@@ -1,0 +1,55 @@
+const chalk = require('chalk')
+const { spawn } = require('child_process')
+const deployContracts = require('./helpers/deploy-contracts')
+const startIpfs = require('./helpers/start-ipfs')
+
+const startGanache = require('./helpers/start-ganache')
+
+const runTests = async (watch) => {
+  return new Promise((resolve, reject) => {
+    const args = [
+      '-r',
+      'babel-register',
+      '-r',
+      'babel-polyfill',
+      '-t',
+      '10000',
+    ]
+    if (watch) {
+      args.push('--watch')
+    } else {
+      args.push('--exit')
+    }
+    args.push('test')
+    console.log('running mocha with args:', args.join(' '))
+
+    const contractTest = spawn('./node_modules/.bin/mocha', args)
+    contractTest.stdout.pipe(process.stdout)
+    contractTest.stderr.on('data', data => {
+      reject(String(data))
+    })
+    contractTest.on('exit', code => {
+      if (code === 0) {
+        console.log(chalk`\n{bold ✅  JavaScript tests passed. :) }\n`)
+        process.exit(0)
+      } else {
+        console.log(chalk`\n{bold ⚠️  JavaScript tests failed. :( }\n`)
+        process.exit(1)
+      }
+    })
+  })
+}
+
+const start = async () => {
+  console.log(chalk`\n{bold.hex('#26d198') ⬢  Starting Local Blockchain }\n`)
+  await startGanache()
+  console.log(chalk`\n{bold.hex('#1a82ff') ⬢  Starting Local IPFS }\n`)
+  await startIpfs()
+  console.log(chalk`\n{bold.hex('#6e3bea') ⬢  Deploying Smart Contracts }\n`)
+  await deployContracts()
+
+  const watch = (process.argv[2] && process.argv[2] == '--watch')
+  await runTests(watch)
+}
+
+start()


### PR DESCRIPTION
### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:

Add `npm` targets to run non-Solidity tests, similar to `test:contracts`
and `test:contractsw`. This should speed up iterations on resource
tests.

Note that the existing `test:js` target didn't work, because it didn't start
IPFS or a local blockchain.
