### PR TITLE
Remove conditional around commissions payout

### DIFF
--- a/contracts/contracts/marketplace/v01/Marketplace.sol
+++ b/contracts/contracts/marketplace/v01/Marketplace.sol
@@ -236,9 +236,7 @@ contract V01_Marketplace is Ownable {
     }
     require(offer.status == 2); // Offer must be in state 'Accepted'
     paySeller(listingID, offerID); // Pay seller
-    if (msg.sender == offer.buyer) { // Only pay commission if buyer is finalizing
-      payCommission(listingID, offerID);
-    }
+    payCommission(listingID, offerID);
     emit OfferFinalized(msg.sender, listingID, offerID, _ipfsHash);
     delete offers[listingID][offerID];
   }


### PR DESCRIPTION
### Checklist:
- [x] Ensure all new and existing tests pass

### Description:

I went through the commissions-related logic in origin-js and I think it's all there and it makes sense except for this one conditional that only allowed commissions to be paid to an affiliate if the buyer finalizes the transaction, but the commissions payment wouldn't happen if the seller finalizes the transaction. 

The seller can only finalize the transaction if the dispute window has passed without a dispute being brought, so I think the affiliate should be paid in either case, whether the buyer or the seller finalizes the transaction. 

Does that make sense to you @nick @tyleryasaka @micahalcorn @franckc @cuongdo ? 
