### PR TITLE
Make origin-js configurable from .env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,7 @@
+BRIDGE_SERVER=https://bridge.originprotocol.com
+IPFS_DOMAIN=gateway.originprotocol.com
+DISCOVERY_SERVER_URL=https://discovery.originprotocol.com
+DISCOVERY_SERVER_PORT=443
+IPFS_API_PORT=5002
+IPFS_GATEWAY_PORT=443
+IPFS_GATEWAY_PROTOCOL=https

--- a/.env
+++ b/.env
@@ -1,7 +1,0 @@
-BRIDGE_SERVER=https://bridge.originprotocol.com
-IPFS_DOMAIN=gateway.originprotocol.com
-DISCOVERY_SERVER_URL=https://discovery.originprotocol.com
-DISCOVERY_SERVER_PORT=443
-IPFS_API_PORT=5002
-IPFS_GATEWAY_PORT=443
-IPFS_GATEWAY_PROTOCOL=https

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ npm-debug.log
 testem.log
 /typings
 .DS_Store
+.env

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ We recommend using [Origin Box](https://github.com/OriginProtocol/origin-box) fo
 git clone https://github.com/OriginProtocol/origin-js.git && cd origin-js
 ```
 
+1. Copy contents of `dev.env` to `.env` and keep the file in the root folder of `origin-js`. Both files `dev.env` and `.env` should be present. The former is used by `webpack` to verify the different variables that need to be set, the latter one is where you set your environmental variables. If you change `.env` variables the build script watching and building `origin-js` needs to be restarted in order to pick up the changes.
+
 1.  Install dependencies and link by running `npm run install:dev`. This script is a shortcut for `npm install && npm link`. Linking means that changes to `origin-js` code are immediately available to local DApps without an `npm install`.
 
 1.  Start the local blockchain and build origin-js by running `npm start`. Code changes will trigger a live rebuild.

--- a/dev.env
+++ b/dev.env
@@ -1,0 +1,7 @@
+BRIDGE_SERVER=https://bridge.originprotocol.com
+IPFS_DOMAIN=gateway.originprotocol.com
+DISCOVERY_SERVER_URL=https://discovery.originprotocol.com
+DISCOVERY_SERVER_PORT=443
+IPFS_API_PORT=5002
+IPFS_GATEWAY_PORT=443
+IPFS_GATEWAY_PROTOCOL=https

--- a/dev.env
+++ b/dev.env
@@ -1,7 +1,6 @@
 BRIDGE_SERVER=https://bridge.originprotocol.com
 IPFS_DOMAIN=gateway.originprotocol.com
-DISCOVERY_SERVER_URL=https://discovery.originprotocol.com
-DISCOVERY_SERVER_PORT=443
+DISCOVERY_SERVER_URL=https://discovery.originprotocol.com:443
 IPFS_API_PORT=5002
 IPFS_GATEWAY_PORT=443
 IPFS_GATEWAY_PROTOCOL=https

--- a/package-lock.json
+++ b/package-lock.json
@@ -4540,6 +4540,19 @@
         "is-obj": "1.0.1"
       }
     },
+    "dotenv": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+      "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
+    },
+    "dotenv-webpack": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-1.5.7.tgz",
+      "integrity": "sha1-xEOVqyHR/SjXmpCUKnsUsd69FF8=",
+      "requires": {
+        "dotenv": "5.0.1"
+      }
+    },
     "drbg.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "bs58": "^4.0.1",
     "cross-fetch": "^2.1.1",
     "crypto-js": "^3.1.9-1",
+    "dotenv-webpack": "1.5.7",
     "ethereumjs-util": "^5.2.0",
     "form-data": "^2.3.2",
     "map-cache": "^0.2.2",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -2,17 +2,24 @@ const chalk = require('chalk')
 const startGanache = require('./helpers/start-ganache')
 const buildContracts = require('./helpers/build-contracts')
 const deployContracts = require('./helpers/deploy-contracts')
+const preBuild = require('./helpers/pre-build')
 const startIpfs = require('./helpers/start-ipfs')
 const startTestServer = require('./helpers/start-test-server')
 const watch = require('node-watch')
 const webpack = require('webpack')
-const webpackConfig = require('../webpack.config.js')
 
 const args = process.argv.slice(2)
 const shouldWatch = args.length && args[0] === 'serve'
 const noGanache = args.length && args[1] === 'no-ganache'
 
 const start = async () => {
+  console.log(chalk`\n{bold.hex('#26d198') ⬢  STARTING BUILD }\n`)
+  preBuild()
+
+  /* We need to load webpack config after preBuild step, because if .evn file does not exist pre-build
+   * copies contents from dev.env to .env. Without .env file webpack config load command fails
+   */
+  const webpackConfig = require('../webpack.config.js')
   const compiler = webpack(webpackConfig)
 
   if (shouldWatch) {

--- a/scripts/helpers/pre-build.js
+++ b/scripts/helpers/pre-build.js
@@ -1,0 +1,9 @@
+const fs = require('fs')
+const fsExtra = require('fs-extra')
+
+module.exports = function() {
+  if (!fs.existsSync(".env")) {
+    console.log(`\nFile .env does not exist. Copying contents from dev.env to .env\n`)
+    fsExtra.copySync('dev.env', '.env')
+  }
+}

--- a/scripts/helpers/pre-build.js
+++ b/scripts/helpers/pre-build.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const fsExtra = require('fs-extra')
 
 module.exports = function() {
-  if (!fs.existsSync(".env")) {
+  if (!fs.existsSync('.env')) {
     console.log(`\nFile .env does not exist. Copying contents from dev.env to .env\n`)
     fsExtra.copySync('dev.env', '.env')
   }

--- a/src/index.js
+++ b/src/index.js
@@ -9,13 +9,13 @@ import Token from './resources/token'
 import fetch from 'cross-fetch'
 import store from 'store'
 
-const defaultBridgeServer = 'https://bridge.originprotocol.com'
-const defaultIpfsDomain = 'gateway.originprotocol.com'
-const defaultDiscoveryServer = 'https://discovery.originprotocol.com'
-const defaultDiscoveryServerPort = '443'
-const defaultIpfsApiPort = '5002'
-const defaultIpfsGatewayPort = '443'
-const defaultIpfsGatewayProtocol = 'https'
+const defaultBridgeServer = process.env.BRIDGE_SERVER
+const defaultIpfsDomain = process.env.IPFS_DOMAIN
+const defaultDiscoveryServer = process.env.DISCOVERY_SERVER_URL
+const defaultDiscoveryServerPort = process.env.DISCOVERY_SERVER_PORT
+const defaultIpfsApiPort = process.env.IPFS_API_PORT
+const defaultIpfsGatewayPort = process.env.IPFS_GATEWAY_PORT
+const defaultIpfsGatewayProtocol = process.env.IPFS_GATEWAY_PROTOCOL
 const defaultAttestationServerUrl = `${defaultBridgeServer}/api/attestations`
 const VERSION = require('.././package.json').version
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,25 +9,17 @@ import Token from './resources/token'
 import fetch from 'cross-fetch'
 import store from 'store'
 
-const defaultBridgeServer = process.env.BRIDGE_SERVER
-const defaultIpfsDomain = process.env.IPFS_DOMAIN
-const defaultDiscoveryServer = process.env.DISCOVERY_SERVER_URL
-const defaultDiscoveryServerPort = process.env.DISCOVERY_SERVER_PORT
-const defaultIpfsApiPort = process.env.IPFS_API_PORT
-const defaultIpfsGatewayPort = process.env.IPFS_GATEWAY_PORT
-const defaultIpfsGatewayProtocol = process.env.IPFS_GATEWAY_PROTOCOL
-const defaultAttestationServerUrl = `${defaultBridgeServer}/api/attestations`
 const VERSION = require('.././package.json').version
 
 class Origin {
   constructor({
-    ipfsDomain = defaultIpfsDomain,
-    ipfsApiPort = defaultIpfsApiPort,
-    ipfsGatewayPort = defaultIpfsGatewayPort,
-    ipfsGatewayProtocol = defaultIpfsGatewayProtocol,
-    attestationServerUrl = defaultAttestationServerUrl,
-    discoveryServer = defaultDiscoveryServer,
-    discoveryServerPort = defaultDiscoveryServerPort,
+    ipfsDomain = process.env.IPFS_DOMAIN,
+    ipfsApiPort = process.env.IPFS_API_PORT,
+    ipfsGatewayPort = process.env.IPFS_GATEWAY_PORT,
+    ipfsGatewayProtocol = process.env.IPFS_GATEWAY_PROTOCOL,
+    attestationServerUrl = `${process.env.BRIDGE_SERVER}/api/attestations`,
+    discoveryServer = process.env.DISCOVERY_SERVER_PORT,
+    discoveryServerPort = process.env.DISCOVERY_SERVER_PORT,
     contractAddresses,
     web3,
     ipfsCreator,

--- a/src/index.js
+++ b/src/index.js
@@ -18,8 +18,7 @@ class Origin {
     ipfsGatewayPort = process.env.IPFS_GATEWAY_PORT,
     ipfsGatewayProtocol = process.env.IPFS_GATEWAY_PROTOCOL,
     attestationServerUrl = `${process.env.BRIDGE_SERVER}/api/attestations`,
-    discoveryServer = process.env.DISCOVERY_SERVER_URL,
-    discoveryServerPort = process.env.DISCOVERY_SERVER_PORT,
+    discoveryServerUrl = process.env.DISCOVERY_SERVER_URL,
     contractAddresses,
     web3,
     ipfsCreator,
@@ -50,8 +49,7 @@ class Origin {
     })
 
     this.discovery = new Discovery({
-      discoveryServer,
-      discoveryServerPort,
+      discoveryServerUrl,
       fetch
     })
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ class Origin {
     ipfsGatewayPort = process.env.IPFS_GATEWAY_PORT,
     ipfsGatewayProtocol = process.env.IPFS_GATEWAY_PROTOCOL,
     attestationServerUrl = `${process.env.BRIDGE_SERVER}/api/attestations`,
-    discoveryServer = process.env.DISCOVERY_SERVER_PORT,
+    discoveryServer = process.env.DISCOVERY_SERVER_URL,
     discoveryServerPort = process.env.DISCOVERY_SERVER_PORT,
     contractAddresses,
     web3,

--- a/src/resources/discovery.js
+++ b/src/resources/discovery.js
@@ -1,9 +1,8 @@
 
 
 class Discovery {
-  constructor({ discoveryServer, discoveryServerPort, fetch }) {
-    this.discoveryServer = discoveryServer
-    this.discoveryServerPort = discoveryServerPort
+  constructor({ discoveryServerUrl, fetch }) {
+    this.discoveryServerUrl = discoveryServerUrl
     this.fetch = fetch
   }
 
@@ -40,7 +39,7 @@ class Discovery {
       }
     }`
 
-    return this.fetch(`${this.discoveryServer}:${this.discoveryServerPort}`, {
+    return this.fetch(this.discoveryServerUrl, {
       method: 'POST',
       body: JSON.stringify({
         query:query

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,11 @@
 var nodeExternals = require('webpack-node-externals');
+var Dotenv = require('dotenv-webpack');
+
+var dotEnvConfig = {
+  path: './.env',
+  safe: './dev.env', // load '.dev.env' to verify the '.env' variables are all set. Can also be a string to a different file.
+  systemvars: true, // load all the predefined 'process.env' variables which will trump anything local per dotenv specs.
+}
 
 var serverConfig = {
   entry: ["babel-polyfill", './src/index.js'],
@@ -10,6 +17,9 @@ var serverConfig = {
   devtool: 'inline-cheap-module-source-map',
   target: 'node',
   externals: [nodeExternals()],
+  plugins: [
+    new Dotenv(dotEnvConfig)
+  ],
   resolve: {
     /**
     * Overriding the default to allow jsx to be resolved automatically.
@@ -44,6 +54,9 @@ var clientConfig = {
   mode: 'production',
   devtool: false,
   target: 'web',
+  plugins: [
+    new Dotenv(dotEnvConfig)
+  ],
   module: {
     rules: [
       {


### PR DESCRIPTION
### Checklist:
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:
- making properties in `origin-js` configurable from `.env` file
- it takes `dev.env` file into consideration regarding what are all the properties that should be defined in `.env` file. Any if any is missing throws an error
- once the origin.js server/client files are built in the `dist` folder configurations from `.env` file are copied into those files and not ready from environmental variables

#### Post Merge Steps
- Resolves Issue: https://github.com/OriginProtocol/origin-js/issues/437
- Also merge this branch once this is merged: https://github.com/OriginProtocol/origin-dapp/pull/480#pullrequestreview-154153057