### PR TITLE
make discovery server url a single parameter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,7 @@ import store from 'store'
 
 const defaultBridgeServer = 'https://bridge.originprotocol.com'
 const defaultIpfsDomain = 'gateway.originprotocol.com'
-const defaultDiscoveryServer = 'https://discovery.originprotocol.com'
-const defaultDiscoveryServerPort = '443'
+const defaultDiscoveryServerUrl = 'https://discovery.originprotocol.com'
 const defaultIpfsApiPort = '5002'
 const defaultIpfsGatewayPort = '443'
 const defaultIpfsGatewayProtocol = 'https'
@@ -26,8 +25,7 @@ class Origin {
     ipfsGatewayPort = defaultIpfsGatewayPort,
     ipfsGatewayProtocol = defaultIpfsGatewayProtocol,
     attestationServerUrl = defaultAttestationServerUrl,
-    discoveryServer = defaultDiscoveryServer,
-    discoveryServerPort = defaultDiscoveryServerPort,
+    discoveryServerUrl = defaultDiscoveryServerUrl,
     contractAddresses,
     web3,
     ipfsCreator,
@@ -58,8 +56,7 @@ class Origin {
     })
 
     this.discovery = new Discovery({
-      discoveryServer,
-      discoveryServerPort,
+      discoveryServerUrl,
       fetch
     })
 

--- a/src/resources/discovery.js
+++ b/src/resources/discovery.js
@@ -1,12 +1,11 @@
 class Discovery {
-  constructor({ discoveryServer, discoveryServerPort, fetch }) {
-    this.discoveryServer = discoveryServer
-    this.discoveryServerPort = discoveryServerPort
+  constructor({ discoveryServerUrl, fetch }) {
+    this.discoveryServerUrl = discoveryServerUrl
     this.fetch = fetch
   }
 
   async query(graphQlQuery){
-    const url = `${this.discoveryServer}:${this.discoveryServerPort}`
+    const url = this.discoveryServerUrl
     const resp = await this.fetch(url, {
       method: 'POST',
       body: JSON.stringify({


### PR DESCRIPTION
### Description:

Dapp already uses a single parameter for discovery server url ( https://github.com/OriginProtocol/origin-dapp/blob/master/src/services/origin.js#L70 ) Lets just change it here also 