### PR TITLE
Add pause & unpause to token_cli

### DIFF
--- a/token/lib/token.js
+++ b/token/lib/token.js
@@ -196,10 +196,14 @@ class Token {
     // `await contract.methods.MyMethod(...).send(...)`:
     //
     // https://github.com/INFURA/infura/issues/95
-    const maxSleep = 15 * 60 * 1000 // 15 minutes, in milliseconds
+
+    // Blocks are mined every ~15 seconds, but it sometimes takes ~40-60 seconds
+    // to get a transaction receipt from rinkeby.infura.io.
+    const maxSleep = 120000
     let totalSleep = 0
     let sleepTime = 1000
     while (totalSleep <= maxSleep) {
+      this.vlog(`waiting ${sleepTime / 1000}s for transaction receipt`)
       await sleep(sleepTime)
 
       if (transactionHash) {
@@ -212,11 +216,9 @@ class Token {
           } else {
             throw new Error('transaction failed')
           }
-        } else {
-          this.vlog('waiting for transaction receipt')
         }
       } else {
-        this.vlog('waiting for transaction hash')
+        this.vlog('still waiting for transaction hash')
       }
 
       sleepTime *= 2

--- a/token/lib/token.js
+++ b/token/lib/token.js
@@ -42,6 +42,16 @@ class Token {
     return TokenContract.networks[networkId].address
   }
 
+  /**
+   * Returns a web3 object with a provider for the given network ID.
+   * @params {string} networkId - Network ID.
+   * @returns {object} - Promise that resolves to contract object.
+   */
+  web3(networkId) {
+    const provider = this.config.providers[networkId]
+    return new Web3(provider)
+  }
+
   /*
    * Returns token contract object for the specified network.
    * @params {string} networkId - Test network Id.
@@ -49,8 +59,7 @@ class Token {
    * @returns {object} - Promise that resolves to contract object.
    */
   contract(networkId) {
-    const provider = this.config.providers[networkId]
-    let web3 = new Web3(provider)
+    const web3 = this.web3(networkId)
 
     // Create a token contract objects based on its ABI and address on the network.
     const contractAddress = this.contractAddress(networkId)
@@ -82,7 +91,8 @@ class Token {
     if (paused) {
       throw new Error('token transfers are paused')
     }
-    await contract.methods.transfer(wallet, value).send({ from: tokenSupplier, gas: 100000 })
+    const transaction = contract.methods.transfer(wallet, value)
+    await this.sendTransaction(networkId, transaction, { from: tokenSupplier })
 
     // Return wallet's balance after credit.
     return this.balance(networkId, wallet)
@@ -100,6 +110,148 @@ class Token {
     const balance = await contract.methods.balanceOf(wallet).call()
     return BigNumber(balance)
   }
+
+  /**
+   * Pauses transfers and approvals of tokens.
+   * @param {string} networkId - Ethereum network ID.
+   */
+  async pause(networkId) {
+    const contract = this.contract(networkId)
+    const sender = this.defaultAccount(networkId)
+
+    // Pre-contract call validations.
+    const alreadyPaused = await contract.methods.paused().call()
+    if (alreadyPaused) {
+      throw new Error('Token is already paused')
+    }
+    const tokenOwner = await contract.methods.owner().call()
+    if (tokenOwner.toLowerCase() != sender.toLowerCase()) {
+      throw new Error(`Sender ${sender} is not owner of token contract (${tokenOwner})`)
+    }
+
+    const transaction = contract.methods.pause()
+    await this.sendTransaction(networkId, transaction, { from: sender })
+    if (await contract.methods.paused().call() !== true) {
+      throw new Error('Token should be paused but is not')
+    }
+  }
+
+  /**
+   * Unpauses transfers and approvals of tokens.
+   * @param {string} networkId - Ethereum network ID.
+   */
+  async unpause(networkId) {
+    const contract = await this.contract(networkId)
+    const sender = this.defaultAccount(networkId)
+
+    // Pre-contract call validations.
+    const paused = await contract.methods.paused().call()
+    if (!paused) {
+      throw new Error('Token is already unpaused')
+    }
+    const tokenOwner = await contract.methods.owner().call()
+    if (tokenOwner.toLowerCase() != sender.toLowerCase()) {
+      throw new Error(`Sender ${sender} is not owner of token contract (${tokenOwner})`)
+    }
+
+    const transaction = contract.methods.unpause()
+    await this.sendTransaction(networkId, transaction, { from: sender })
+    if (await contract.methods.paused().call() !== false) {
+      throw new Error('Token should be unpaused but is not')
+    }
+  }
+
+  // TODO: refactor into separate base class, to support other contracts such
+  // as the marketplace contract
+  /**
+   * Sends an Ethereum transaction.
+   * @param {string} networkId - Ethereum network ID.
+   * @param {transaction} transaction - These are returned by contract.methods.MyMethod()
+   * @param {Object} opts - Options to be sent along with the transaction.
+   * @returns {Object} - Transaction receipt.
+   */
+  async sendTransaction(networkId, transaction, opts = {}) {
+    // TODO: support multisig wallets
+
+    const web3 = this.web3(networkId)
+
+    let transactionHash
+    if (!opts.gas) {
+      opts.gas = await transaction.estimateGas({ from: opts.from })
+      this.vlog('estimated gas:', opts.gas)
+    }
+
+    // Send the transaction and grab the transaction hash when it's available.
+    this.vlog('sending transaction')
+    transaction.send(opts)
+      .on('transactionHash', (hash) => {
+        transactionHash = hash
+        this.vlog('transaction hash:', transactionHash)
+      })
+
+    // Poll for the transaction receipt, with an exponential backoff. This works
+    // around some strange interactions between web3.js and some web3 providers.
+    // For example, this issue sometimes prevents transaction receipts from
+    // being returned when simply calling
+    // `await contract.methods.MyMethod(...).send(...)`:
+    //
+    // https://github.com/INFURA/infura/issues/95
+    const maxSleep = 15 * 60 * 1000 // 15 minutes, in milliseconds
+    let totalSleep = 0
+    let sleepTime = 1000
+    while (totalSleep <= maxSleep) {
+      await sleep(sleepTime)
+
+      if (transactionHash) {
+        const receipt = await web3.eth.getTransactionReceipt(transactionHash)
+        if (receipt) {
+          this.vlog('got transaction receipt', receipt)
+          if (receipt.status) {
+            this.vlog('transaction successful')
+            return receipt
+          } else {
+            throw new Error('transaction failed')
+          }
+        } else {
+          this.vlog('waiting for transaction receipt')
+        }
+      } else {
+        this.vlog('waiting for transaction hash')
+      }
+
+      sleepTime *= 2
+      totalSleep += sleepTime
+    }
+  }
+
+  /**
+   * Logs provided arguments with a timestamp if this.verbose is true.
+   */
+  // TODO: refactor into separate base class
+  vlog(/* all arguments are passed to console.log */) {
+    if (this.config.verbose) {
+      console.log(new Date().toString(), ...arguments)
+    }
+  }
+
+  /**
+   * Returns the default Ethereum account.
+   * @param {int} networkId - Network ID.
+   * @returns {string} - Address of default of first unlocked account.
+   */
+  defaultAccount(networkId) {
+    const provider = this.config.providers[networkId]
+    return provider.addresses[0]
+  }
+}
+
+/**
+ * Returns a promise that resolves after the specified duration.
+ * @param {int} ms - Milliseconds to sleep for.
+ * @returns {Promise} - Promise that resolves after ms milliseconds.
+ */
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 module.exports = Token

--- a/token/scripts/token_cli.js
+++ b/token/scripts/token_cli.js
@@ -28,6 +28,18 @@ async function run(config) {
     console.log(`Token contract address = ${address}`)
     break
   }
+  case 'pause': {
+    config.verbose = true
+    await token.pause(config.networkId)
+    console.log('Token transfers have been paused.')
+    break
+  }
+  case 'unpause': {
+    config.verbose = true
+    await token.unpause(config.networkId)
+    console.log('Token transfers have been paused.')
+    break
+  }
   default:
     throw `Unsupported action ${config.action}`
   }
@@ -48,6 +60,9 @@ const config = {
 
   // Target wallet for the action.
   wallet: args['--wallet'],
+
+  // Verbose logs.
+  verbose: false,
 }
 
 try {
@@ -59,4 +74,4 @@ try {
 
 run(config)
   .then(() => {process.exit(0)})
-  .catch((err) => {console.log(`Error: ${err}`); process.exit(-1)})
+  .catch((err) => { console.trace(err); process.exit(-1) })


### PR DESCRIPTION
### Checklist:

- [ ] ~~Code contains relevant tests for the problem you are solving~~
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:

This adds the `pause` and `unpause` actions to the token CLI, which
pause and unpause token transfers. These may only be called by the token
contract owner.

This also adds `sendTransaction` to the token library, which sends an
Ethereum transaction and polls for the receipt. This is necessary
workaround for an issue where the normal `contract.methods.MyMethod.send()`
function never returns a transaction receipt for certain calls:

https://github.com/INFURA/infura/issues/95

Manually tested the token faucet on Rinkeby & localhost to ensure that it still
works.
