### PR TITLE
Clean up use of schemaVersion in sample-data.js script

### DIFF
--- a/scripts/sample-data.js
+++ b/scripts/sample-data.js
@@ -102,7 +102,6 @@ async function createSampleData() {
     )
 
     const newListing = await o.marketplace.createListing({
-      schemaVersion: '1.0.0',
       listingType: 'unit',
       title: listingName,
       category: CATEGORIES[Math.floor(Math.random() * CATEGORIES.length)],
@@ -131,7 +130,6 @@ async function createSampleData() {
       }}`
     )
     await o.marketplace.makeOffer(listing.id, {
-      schemaVersion: '1.0.0',
       listingType: 'unit',
       unitsPurchased: 1,
       totalPrice: listing.price


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [ ] Code contains relevant tests for the problem you are solving
- [X] Ensure all new and existing tests pass
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:
Passing the schemaVersion field in the data is no longer necessary when creating a listing. Origin-js picks the current schema.