### PR TITLE
Support Commission

### DIFF
--- a/contracts/test-alt/Marketplace.js
+++ b/contracts/test-alt/Marketplace.js
@@ -531,10 +531,16 @@ describe('Marketplace.sol', async function() {
         [IpfsHash, 5, ArbitratorAddr]
       )
 
+      const balance_pre = await OriginToken.methods.balanceOf(Seller2).call({from:Seller2})
+
       await OriginToken.methods
         .approveAndCallWithSender(Marketplace._address, 5, fnSig, params)
         .send({ from: Seller2 })
         .once('receipt', trackGas('Create Listing via call'))
+
+      const balance_post = await OriginToken.methods.balanceOf(Seller2).call({from:Seller2})
+      assert.equal(Number(balance_pre), Number(balance_post) + 5)
+
     })
   })
 

--- a/src/adapters/marketplace/v00.js
+++ b/src/adapters/marketplace/v00.js
@@ -351,19 +351,17 @@ class V00_MarkeplaceAdapter {
     return this.web3.utils.padLeft(this.web3.utils.numberToHex(id), 64)
   }
 
-  async _getTokenCreateListingParams(/*variable argument accepted here*/) {
+  async _getTokenCreateListingParams(...args) {
     await this.getContract()
-    for (const call of this.contract.options.jsonInterface)
-    {
-      if (call.name === 'createListingWithSender' && call.type === 'function' && call.signature)
-      {
+    for (const call of this.contract.options.jsonInterface) {
+      if (call.name === 'createListingWithSender' && call.type === 'function' && call.signature) {
         const market_address = this.contract.options.address
         // take out the first parameter which is hopefully the seller address
         const input_types = call.inputs.slice(1).map(e => e.type)
-        if (input_types.length != arguments.length){
+        if (input_types.length != args.length){
           throw('The number of parameters passed does not match the contract parameters')
         }
-        const call_params = this.web3.eth.abi.encodeParameters(input_types, arguments)
+        const call_params = this.web3.eth.abi.encodeParameters(input_types, args)
         const selector = call.signature
         return {market_address, selector, call_params}
       }

--- a/src/services/contract-service.js
+++ b/src/services/contract-service.js
@@ -188,7 +188,7 @@ class ContractService {
     contractName,
     functionName,
     args = [],
-    { contractAddress, from, gas, value, confirmationCallback } = {}
+    { contractAddress, from, gas, value, confirmationCallback, extra_gas = 0 } = {}
   ) {
     const contractDefinition = this.contracts[contractName]
     if (typeof contractDefinition === 'undefined') {
@@ -207,7 +207,7 @@ class ContractService {
       return await method.call(opts)
     }
     // set gas
-    opts.gas = opts.gas || (await method.estimateGas(opts))
+    opts.gas = (opts.gas || (await method.estimateGas(opts))) + extra_gas
     const transactionReceipt = await new Promise((resolve, reject) => {
       method
         .send(opts)

--- a/test/helpers/contract-service-helper.js
+++ b/test/helpers/contract-service-helper.js
@@ -28,6 +28,8 @@ export default async function contractServiceHelper(web3) {
     { from: accounts[0], gas: 4000000 }
   )
 
+  await originToken.methods.addCallSpenderWhitelist(v01_marketplace.contractAddress).send({ from: accounts[0], gas: 4000000 })
+
   return new ContractService({
     web3,
     contractAddresses: {


### PR DESCRIPTION
This adds support for the commission to be handled in `createListing`. It also repairs the `contract` reference and `arguments` used in `_getTokenCreateListingParams`.

This still produces an unidentified rpc error:

```
Returned error: Error: Error: [ethjs-rpc] rpc error with payload {
"id":706241195408,
"jsonrpc":"2.0",
"params":[
"0xf9016e068609184e72a0008302752e94345ca3e014aaf5dca488057592ee47305d9b3e1080b9010482857a030000000000000000000000008f0483125fcb9aaaefa9209d8e9d7b9c8b9fb90f00000000000000000000000000000000000000000000000542253a126ce40000de40062900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000600386f6684fc0df79d08cdc840f7036f002eb5f54e2d79fddc5be677dde32680800000000000000000000000000000000000000000000000542253a126ce40000000000000000000000000000f17f52151ebef6c7334fad080c5704d77216b7328207f2a0ed3943457ac58f7c91a0ff95367b36465987611814c69bbd0bc1592d68398ba8a0040af976d72b2a573c72402e52ab31e48ff040144cedeae3c696b2a81bd5bdb7"
],
"method":"eth_sendRawTransaction"
} Error: VM Exception while processing transaction: revert proxied call failed
```