### PR TITLE
Use pathExistsSync

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -42,7 +42,7 @@ const start = async () => {
   // If the contract build directory does not exist or is empty,
   // copy the compiled contract files from the latest release into it.
   const dstDir = 'contracts/build/contracts'
-  if (fs.pathExists(dstDir) && fs.readdirSync(dstDir).length > 0) {
+  if (fs.pathExistsSync(dstDir) && fs.readdirSync(dstDir).length > 0) {
     console.log(chalk.blue('Contracts build directory already exists and not empty, skipping copy.'))
   } else {
     copyReleaseCompiledContracts(dstDir)


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:

Contract copy was using async version of pathExists which caused the second predicate in the if statement to be called on a non-existent directory causing build to fail with the following error:

`UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory, scandir 'contracts/build/contracts'`

Easy fix :tada: 