### PR TITLE
Fix service-data-store.test.js test

### DIFF
--- a/test/service-data-store.test.js
+++ b/test/service-data-store.test.js
@@ -104,7 +104,10 @@ describe('Listing IpfsDataStore save', () => {
       .stub()
       .returns('http://test-gateway')
 
-    return expect(store.save(LISTING_DATA_TYPE, validListing)).to.eventually.equal('ListingHash')
+    // Clone validListing, because IpfsDataStore.save() filters out the test
+    // media URLs, which appear to be invalid.
+    const validListingCopy = JSON.parse(JSON.stringify(validListing))
+    return expect(store.save(LISTING_DATA_TYPE, validListingCopy)).to.eventually.equal('ListingHash')
       .then(() => expect(mockIpfsService.saveDataURIAsFile.callCount).to.equal(0))
       .then(() => expect(mockIpfsService.gatewayUrlForHash.callCount).to.equal(0))
       .then(() => expect(mockIpfsService.saveObjAsFile.firstCall.args[0]).to.have.property('schemaId'))


### PR DESCRIPTION
### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:

Reruns of service-data-store.test.js would fail, because the save()
in this line:

https://github.com/OriginProtocol/origin-js/blob/master/test/service-data-store.test.js#L107

causes future runs of this line:

https://github.com/OriginProtocol/origin-js/blob/master/test/service-data-store.test.js#L60

to fail.

save() filters out media URLs that seem malformed, and the test URLs
look malformed to it. This unbreaks this test for use in `npm run
test:jsw`.
