### PR TITLE
Use moneyToUnits instead of toWei

### DIFF
--- a/src/adapters/marketplace/v00.js
+++ b/src/adapters/marketplace/v00.js
@@ -53,9 +53,7 @@ class V00_MarkeplaceAdapter {
       throw(`${currency} is not a supported deposit currency`)
     }
     if (amount > 0) {
-      deposit = this.contractService.web3.utils.toWei(
-        amount.toString()
-      )
+      deposit = this.contractService.moneyToUnits(commission)
       const {market_address, selector, call_params} = await this._getTokenAndCallWithSenderParams('createListingWithSender', ipfsBytes, deposit, arbitrator || from)
 
       // In order to estimate gas correctly, we need to add the call to a create listing since that's called by the token


### PR DESCRIPTION
### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:

moneyToUnits handles ERC20 currencies in addition to ETH. toWei would be incorrect for currencies with decimals other than 18.