### PR TITLE
Listings Repairs

### DIFF
--- a/src/adapters/marketplace/_resolver.js
+++ b/src/adapters/marketplace/_resolver.js
@@ -223,8 +223,9 @@ class MarketplaceResolver {
     // Get all the OfferFinalized events for the listing.
     const listing = await adapter.getListing(listingIndex)
     const reviewEvents = listing.events.filter(
-      e => e.event === 'OfferFinalized'
+      e => e.event === 'OfferFinalized' || e.event === 'OfferData'
     )
+
     return Promise.all(
       reviewEvents.map(async event => {
         const offerIndex = event.returnValues.offerID

--- a/src/resources/marketplace.js
+++ b/src/resources/marketplace.js
@@ -37,7 +37,7 @@ class Marketplace {
   }
 
   async getListings(opts = {}) {
-    const listingIds = await this.resolver.getListingIds()
+    const listingIds = await this.resolver.getListingIds(opts)
 
     if (opts.idsOnly) {
       return listingIds


### PR DESCRIPTION
Two repairs to listings:

- passes `opts` to the resolver in order to support `listingsFor` or `purchasesFor`
- includes reviews saved with `OfferData` events (from sellers after `OfferFinalized`)