### PR TITLE
Skip sample listing creation on Rinkeby and Ropsten

### DIFF
--- a/contracts/migrations/3_create_sample_listings.js
+++ b/contracts/migrations/3_create_sample_listings.js
@@ -2,8 +2,8 @@ const V00_Marketplace = artifacts.require('./V00_Marketplace.sol')
 
 module.exports = function(deployer, network) {
   return deployer.then(() => {
-    if (network === 'mainnet') {
-      console.log('Skipping sample listings on mainnet')
+    if (network === 'mainnet' || network === 'rinkeby' || network === 'ropsten') {
+      console.log(`Skipping sample listings creation on ${network}`)
     } else {
       return deployContracts(deployer)
     }


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [ ] Code contains relevant tests for the problem you are solving
- [X] Ensure all new and existing tests pass
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:
The way we are currently generating sample listings, makes it impossible to make on offer on them.
For more details see #478 

As a short-term solution, commenting out creation of sample listings on Rinkeby and Ropsten while we work on a solution. For the v0.8.0 Testnet release, we can create those sample listings manually if we want to.
