### PR TITLE
Fix Money

### DIFF
--- a/src/services/contract-service.js
+++ b/src/services/contract-service.js
@@ -58,6 +58,7 @@ class ContractService {
 
     this.currencies = Object.assign(
       { ETH: { address: emptyAddress } },
+      { OGN: { decimals: '18' } },
       currencies
     )
   }


### PR DESCRIPTION
Deposits were broken by https://github.com/OriginProtocol/origin-js/pull/485 because the number of decimals is not provided. I know that hard-coding the number here is not ideal, but I'm unclear on how to access the token contract method (`decimals()`) from this point in the `ContractService` constructor or how exactly you intended to populate the `currency.decimals` value.