### PR TITLE
Throw error when ipfsHash not found.

### DIFF
--- a/src/contractInterface/marketplace/v00_adapter.js
+++ b/src/contractInterface/marketplace/v00_adapter.js
@@ -234,6 +234,10 @@ class V00_MarkeplaceAdapter {
       }
     })
 
+    if (!ipfsHash) {
+      throw(`ipfsHash not found in events for listing ${listingId}`)
+    }
+
     // Return the raw listing along with events and IPFS hash
     return Object.assign({}, rawListing, { ipfsHash, events, offers, status })
   }


### PR DESCRIPTION
Was a bitch to figure why we were getting an `undefined` for `ipfsHash`. This check will alert us in future if contract events are not working right. 