### PR TITLE
Removing extra null in getPastEvents() query

### DIFF
--- a/src/contractInterface/marketplace/v00_adapter.js
+++ b/src/contractInterface/marketplace/v00_adapter.js
@@ -356,7 +356,7 @@ class V00_MarkeplaceAdapter {
     const partyOfferIds = []
 
     const events = await this.contract.getPastEvents('allEvents', {
-      topics: [null, this.padTopic(party), null, null],
+      topics: [null, this.padTopic(party)],
       fromBlock: 0
     })
 

--- a/src/contractInterface/marketplace/v00_adapter.js
+++ b/src/contractInterface/marketplace/v00_adapter.js
@@ -204,7 +204,7 @@ class V00_MarkeplaceAdapter {
     // Find all events related to this listing
     const listingTopic = this.padTopic(listingId)
     const events = await this.contract.getPastEvents('allEvents', {
-      topics: [null, null, listingTopic, null],
+      topics: [null, null, listingTopic],
       fromBlock: 0
     })
 


### PR DESCRIPTION
This removes a `null` from the `getPastEvents` query in a few places. This could be what is causing the listings to not show up on demo.staging.originprotocol.com.

The issue is that without events being found, it doesn't set the `ipfsHash` in the `getListing()` call, so no IPFS data is found.