### PR TITLE
Remove unused securityDeposit field

### DIFF
--- a/src/ipfsInterface/adapters/listing/v1-listing-adapter.js
+++ b/src/ipfsInterface/adapters/listing/v1-listing-adapter.js
@@ -81,9 +81,6 @@ export default class ListingAdapterV1 extends AdapterBase {
       listing.commission = ipfsData.commission
         ? new Money(ipfsData.commission)
         : null
-      listing.securityDeposit = ipfsData.securityDeposit
-        ? new Money(ipfsData.securityDeposit)
-        : null
     } else if (listing.type === 'fractional') {
       // TODO(franck): fill this in.
     } else {

--- a/src/ipfsInterface/schemas/listing.json
+++ b/src/ipfsInterface/schemas/listing.json
@@ -151,9 +151,6 @@
     },
     "commission": {
       "$ref": "#/definitions/money"
-    },
-    "securityDeposit": {
-      "$ref": "#/definitions/money"
     }
   },
   "listingType": {

--- a/test/fixtures/hawaii-house/hawaii-house.json
+++ b/test/fixtures/hawaii-house/hawaii-house.json
@@ -14,9 +14,5 @@
   "commission": {
     "currency": "OGN",
     "amount": "10"
-  },
-  "securityDeposit": {
-    "currency": "ETH",
-    "amount": "10"
   }
 }

--- a/test/fixtures/lake-house/lake-house.json
+++ b/test/fixtures/lake-house/lake-house.json
@@ -14,9 +14,5 @@
   "commission": {
     "currency": "OGN",
     "amount": "10"
-  },
-  "securityDeposit": {
-    "currency": "ETH",
-    "amount": "1"
   }
 }

--- a/test/fixtures/listing-valid.json
+++ b/test/fixtures/listing-valid.json
@@ -33,9 +33,5 @@
   "commission": {
     "currency": "OGN",
     "amount": "0"
-  },
-  "securityDeposit": {
-    "currency": "ETH",
-    "amount": "100"
   }
 }

--- a/test/fixtures/zinc-house/zinc-house.json
+++ b/test/fixtures/zinc-house/zinc-house.json
@@ -14,9 +14,5 @@
   "commission": {
     "currency": "OGN",
     "amount": "10"
-  },
-  "securityDeposit": {
-    "currency": "ETH",
-    "amount": "1.001"
   }
 }

--- a/test/ipfs_store.test.js
+++ b/test/ipfs_store.test.js
@@ -62,10 +62,6 @@ describe('Listing IpfsDataStore load', () => {
     expect(listing.unitsTotal).to.equal(1)
     expect(listing.price).to.deep.equal({ amount: '0.033', currency: 'ETH' })
     expect(listing.commission).to.deep.equal({ amount: '0', currency: 'OGN' })
-    expect(listing.securityDeposit).to.deep.equal({
-      amount: '100',
-      currency: 'ETH'
-    })
     expect(listing.ipfs.hash).to.equal('TestHash')
     expect(listing.ipfs.data).to.deep.equal(validListing)
   })


### PR DESCRIPTION
Per #528, the securityDeposit field in IPFS is not currently being used and should be removed.