### PR TITLE
Specify the event name in getPastEvents call

### DIFF
--- a/contracts/contracts/identity/ERC735.sol
+++ b/contracts/contracts/identity/ERC735.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.4.24;
 contract ERC735 {
 
     event ClaimRequested(uint256 indexed claimRequestId, uint256 indexed topic, uint256 scheme, address indexed issuer, bytes signature, bytes data, string uri);
-    event ClaimAdded(bytes32 indexed claimId, uint256 indexed topic, address indexed issuer, uint256 signatureType, bytes32 signature, bytes claim, string uri);
     event ClaimAdded(bytes32 indexed claimId, uint256 indexed topic, uint256 scheme, address indexed issuer, bytes signature, bytes data, string uri);
     event ClaimRemoved(bytes32 indexed claimId, uint256 indexed topic, uint256 scheme, address indexed issuer, bytes signature, bytes data, string uri);
     event ClaimChanged(bytes32 indexed claimId, uint256 indexed topic, uint256 scheme, address indexed issuer, bytes signature, bytes data, string uri);

--- a/src/contractInterface/users/v00_adapter.js
+++ b/src/contractInterface/users/v00_adapter.js
@@ -156,12 +156,9 @@ class V00_UsersAdapter {
       this.contractService.contracts.ClaimHolderRegistered,
       identityAddress
     )
-    const allEvents = await identity.getPastEvents('allEvents', {
+    const claimAddedEvents = await identity.getPastEvents('ClaimAdded', {
       fromBlock: 0
     })
-    const claimAddedEvents = allEvents.filter(
-      ({ event }) => event === 'ClaimAdded'
-    )
     const mapped = claimAddedEvents.map(({ returnValues }) => {
       return {
         claimId: returnValues.claimId,


### PR DESCRIPTION
### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:

It's more performant to include the name in the query rather than filtering afterwards. Incidentally, this also seems to resolve the issue in https://github.com/OriginProtocol/origin-dapp/issues/547