### PR TITLE
Issue/reason strings

### DIFF
--- a/src/contractInterface/marketplace/v00_adapter.js
+++ b/src/contractInterface/marketplace/v00_adapter.js
@@ -234,6 +234,10 @@ class V00_MarkeplaceAdapter {
       }
     })
 
+    if (!ipfsHash) {
+      throw(`ipfsHash not found in events for listing ${listingId}`)
+    }
+
     // Return the raw listing along with events and IPFS hash
     return Object.assign({}, rawListing, { ipfsHash, events, offers, status })
   }


### PR DESCRIPTION
• Capitalized reason strings to match convention of other contracts, except when its a var or function name.
• Changed `state` to `status` to prevent possible confusion, as that's the actual variable name in contract, and `state` is a common variable name elsewhere (e.g. used in React a lot) 
