### PR TITLE
Bump version to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "origin",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "",
   "engines": {
     "node": "9.11.1"


### PR DESCRIPTION
Bump version to 0.8.0 now that we have new contracts and code. 

Probably should have done this when deploying the new contracts...made a note in the push plan. 