### PR TITLE
Remove duplicate listener rules

### DIFF
--- a/daemon/indexing/listener/listener.js
+++ b/daemon/indexing/listener/listener.js
@@ -101,20 +101,6 @@ const LISTEN_RULES = {
     OfferRuling: getOfferDetails,
     OfferFinalized: getOfferDetails,
     OfferData: getOfferDetails
-  },
-  V00_Marketplace: {
-    ListingCreated: getListingDetails,
-    ListingUpdated: getListingDetails,
-    ListingWithdrawn: getListingDetails,
-    ListingData: getListingDetails,
-    ListingArbitrated: getListingDetails,
-    OfferCreated: getOfferDetails,
-    OfferWithdrawn: getOfferDetails,
-    OfferAccepted: getOfferDetails,
-    OfferDisputed: getOfferDetails,
-    OfferRuling: getOfferDetails,
-    OfferFinalized: getOfferDetails,
-    OfferData: getOfferDetails
   }
 }
 


### PR DESCRIPTION
Looks like we got a duplicate left over from when we had the v00 marketplace lying around.

EDIT: Or...do we need two entries in this array for some reason? (I've never worked in the listener codebase!)