### PR TITLE
 Rename listing `arbitrator` to `depositManager` + reason strings tweaks

### DIFF
--- a/contracts/contracts/marketplace/v00/Marketplace.sol
+++ b/contracts/contracts/marketplace/v00/Marketplace.sol
@@ -161,7 +161,7 @@ contract V00_Marketplace is Ownable {
     // @dev Listing depositManager withdraws listing. IPFS hash contains reason for withdrawl.
     function withdrawListing(uint listingID, address _target, bytes32 _ipfsHash) public {
         Listing storage listing = listings[listingID];
-        require(msg.sender == listing.depositManager, "depositManager required");
+        require(msg.sender == listing.depositManager, "Must be depositManager");
         require(_target != 0x0, "No target");
         tokenAddr.transfer(_target, listing.deposit); // Send deposit to target
         delete listings[listingID]; // Remove data to get some gas back


### PR DESCRIPTION
We agreed to rename the Listing's `arbitrator` to `depositManager` to avoid confusion, here:
https://github.com/OriginProtocol/origin-js/issues/541#issuecomment-424464148
 
Also cherry picked of reason-string updates from `staging` to make future merging easier. 