### PR TITLE
Fix getOffer() arbitrator and affiliate checking

### DIFF
--- a/src/resources/marketplace.js
+++ b/src/resources/marketplace.js
@@ -133,11 +133,11 @@ class Marketplace {
         throw new Error('Invalid offer: insufficient commission amount for listing')
       }
 
-      if (chainOffer.arbitrator !== this.arbitrator) {
+      if (chainOffer.arbitrator.toLowerCase() !== this.arbitrator.toLowerCase()) {
         throw new Error('Invalid offer: arbitrator is invalid')
       }
 
-      if (chainOffer.affiliate !== this.affiliate) {
+      if (chainOffer.affiliate.toLowerCase() !== this.affiliate.toLowerCase()) {
         throw new Error('Invalid offer: affiliate is invalid')
       }
     }


### PR DESCRIPTION
### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:

Fix getOffer() arbitrator and affiliate checking

Sometimes, some characters in addresses are upper-cased. Not sure why,
but the net result is that addresses must be compared case
insensitively.  I observed this locally, and it prevented in-progress
offers from showing up on the buyer or seller side.
