### PR TITLE
add feature and hidden listings logic

### DIFF
--- a/daemon/indexing/apollo/index.js
+++ b/daemon/indexing/apollo/index.js
@@ -253,7 +253,7 @@ const resolvers = {
       }
     },
     async listing(root, args, context, info) {
-      return search.Listing.get(args.id)
+      return search.Listing.get(args.id, hiddenListings, featuredListings)
     },
     async offers(root, args, context, info){
       const opts = {}

--- a/daemon/indexing/apollo/index.js
+++ b/daemon/indexing/apollo/index.js
@@ -384,7 +384,7 @@ async function updateHiddenFeaturedListings(){
       hiddenListings = await readListingsFromGist(hiddenListingsGist)
       featuredListings = await readListingsFromGist(featuredListingsGist)
     } catch(e) {
-      console.err("Could not update hidden/featured listings ", e)
+      console.error("Could not update hidden/featured listings ", e)
     }
   }
 }
@@ -395,10 +395,11 @@ const server = new ApolloServer({
   typeDefs,
   resolvers,
   context: async ({req}) => {
-      await updateHiddenFeaturedListings()
+    // update listingIds in a non blocking way
+    updateHiddenFeaturedListings()
 
-      return {}
-    }
+    return {}
+  }
 })
 
 // The `listen` method launches a web-server.

--- a/daemon/indexing/lib/search.js
+++ b/daemon/indexing/lib/search.js
@@ -73,20 +73,16 @@ class Listing {
     return listingId
   }
 
-  static getListingDisplayType(listingId, hiddenIds, featuredIds) {
+  static extractListing(elasticSearchHit, hiddenIds, featuredIds){
     let displayType = "normal"
     /* hidden listings are not returned right now, but at some point in the future
      * we might have admin queries that also return hidden listings
      */
-    if (hiddenIds.includes(listingId))
+    if (hiddenIds.includes(elasticSearchHit._id))
       displayType = "hidden"
-    else if (featuredIds.includes(listingId))
+    else if (featuredIds.includes(elasticSearchHit._id))
       displayType = "featured"
 
-    return displayType
-  }
-
-  static extractListing(elasticSearchHit, hiddenIds, featuredIds){
     return {
       id: elasticSearchHit._id,
       title: elasticSearchHit._source.title,
@@ -95,9 +91,10 @@ class Listing {
       description: elasticSearchHit._source.description,
       priceAmount: (elasticSearchHit._source.price||{}).amount,
       priceCurrency: (elasticSearchHit._source.price||{}).currency,
-      displayType: this.getListingDisplayType(elasticSearchHit._id, hiddenIds, featuredIds)
+      displayType: displayType
     }
   }
+
   /**
    * Searches for listings.
    * @param {string} query - The search query.

--- a/daemon/indexing/listener/listener.js
+++ b/daemon/indexing/listener/listener.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const http = require('http')
 const urllib = require('url')
-const Origin = require('origin')
+const Origin = require('../../../dist/index')
 const Web3 = require('web3')
 
 const search = require('../lib/search.js')

--- a/daemon/indexing/package.json
+++ b/daemon/indexing/package.json
@@ -9,10 +9,11 @@
     "elasticsearch": "^15.1.1",
     "graphql": "^0.13.2",
     "http": "0.0.0",
+    "node-fetch": "^2.2.0",
+    "origin": "~0.7.0",
     "pg": "^7.4.3",
     "url": "^0.11.0",
-    "web3": "^1.0.0-beta.35",
-    "origin": "~0.7.0"
+    "web3": "^1.0.0-beta.35"
   },
   "devDependencies": {}
 }

--- a/src/resources/discovery.js
+++ b/src/resources/discovery.js
@@ -64,6 +64,7 @@ class Discovery {
       ) {
         nodes {
           id
+          displayType
         }
         offset
         numberOfItems

--- a/src/resources/discovery.js
+++ b/src/resources/discovery.js
@@ -78,6 +78,17 @@ class Discovery {
 
     return this.query(query)
   }
+
+  async getListing(listingId) {
+    return this.query(`{
+      listing (
+        id: "${listingId}"
+      ) {
+        id
+        displayType
+      }
+    }`)
+  }
 }
 
 module.exports = Discovery


### PR DESCRIPTION
### Checklist:
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:
Reads hidden/featured listings from gist file and considers them when returning search results from elasticsearch. Hidden listings are omitted from results, featured listings are returned at the top of the search results and marked as `featured`. Query and filters still apply to featured listings, they are just always sorted at the top. 

**Important:**
- [ ] currently there are 2 gist files and are tied to my account (sparrowDom) This should be changed to someone more core to origin team, and/or someone who will be in charge of hiding/featuring listings. Before merge we should change that. 
- Gist file links point to a specific version of file. For that reason `rawgit.com` service is used, that always redirects to latest version of file in gist. It is important that we use production rawgit links that update less frequently and are not limited by the number of requests. 

**Solves issue:** https://github.com/OriginProtocol/origin-dapp/issues/594
**Connected Pull Request:**https://github.com/OriginProtocol/origin-dapp/pull/617