### PR TITLE
 🎧 Listener - HTTPS webhook support

### DIFF
--- a/daemon/indexing/listener/listener.js
+++ b/daemon/indexing/listener/listener.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const http = require('http')
+const https = require('https')
 const urllib = require('url')
 const Origin = require('origin')
 const Web3 = require('web3')
@@ -373,15 +374,16 @@ async function postToWebhook(urlString, json) {
     }
   }
   return new Promise((resolve, reject) => {
-    const req = http.request(postOptions, res => {
+    const client = url.protocol == 'https:' ? https : http
+    const req = client.request(postOptions, res => {
       if (res.statusCode === 200) {
         resolve()
       } else {
         reject()
       }
     })
-    req.on('error', () => {
-      reject()
+    req.on('error', (err) => {
+      reject(err)
     })
     req.write(json)
     req.end()

--- a/daemon/indexing/listener/listener.js
+++ b/daemon/indexing/listener/listener.js
@@ -374,7 +374,7 @@ async function postToWebhook(urlString, json) {
     }
   }
   return new Promise((resolve, reject) => {
-    const client = url.protocol == 'https:' ? https : http
+    const client = url.protocol === 'https:' ? https : http
     const req = client.request(postOptions, res => {
       if (res.statusCode === 200) {
         resolve()


### PR DESCRIPTION
Allows the listener to post to HTTP or HTTPS webhook urls. Previously we only supported HTTP.

Probably a lower priority at this time, and can go in after the mainnet beta next week.