### PR TITLE
Add block epoch

### DIFF
--- a/src/contractInterface/marketplace/resolver.js
+++ b/src/contractInterface/marketplace/resolver.js
@@ -13,9 +13,9 @@ import {
 } from '../../models/notification'
 
 class MarketplaceResolver {
-  constructor({ contractService, store }) {
+  constructor({ contractService, store, blockEpoch }) {
     this.adapters = {
-      '000': new V00_MarkeplaceAdapter({ contractService, store })
+      '000': new V00_MarkeplaceAdapter({ contractService, store, blockEpoch })
     }
     this.versions = ['000']
     this.currentVersion = this.versions[this.versions.length - 1]

--- a/src/contractInterface/marketplace/v00_adapter.js
+++ b/src/contractInterface/marketplace/v00_adapter.js
@@ -12,11 +12,12 @@ const SUPPORTED_DEPOSIT_CURRENCIES = ['OGN']
 const emptyAddress = '0x0000000000000000000000000000000000000000'
 
 class V00_MarkeplaceAdapter {
-  constructor({ contractService }) {
+  constructor({ contractService, blockEpoch }) {
     this.web3 = contractService.web3
     this.contractService = contractService
     this.contractName = 'V00_Marketplace'
     this.tokenContractName = 'OriginToken'
+    this.blockEpoch = blockEpoch || 0
   }
 
   async getContract() {
@@ -237,7 +238,7 @@ class V00_MarkeplaceAdapter {
     const listingTopic = this.padTopic(listingId)
     const events = await this.contract.getPastEvents('allEvents', {
       topics: [null, null, listingTopic],
-      fromBlock: 0
+      fromBlock: this.blockEpoch
     })
 
     let status = 'active'
@@ -277,7 +278,7 @@ class V00_MarkeplaceAdapter {
     if (opts.purchasesFor) {
       const events = await this.contract.getPastEvents('OfferCreated', {
         filter: { party: opts.purchasesFor },
-        fromBlock: 0
+        fromBlock: this.blockEpoch
       })
       const listingIds = []
       events.forEach(e => {
@@ -290,7 +291,7 @@ class V00_MarkeplaceAdapter {
     } else if (opts.listingsFor) {
       const events = await this.contract.getPastEvents('ListingCreated', {
         filter: { party: opts.listingsFor },
-        fromBlock: 0
+        fromBlock: this.blockEpoch
       })
       return events.map(e => Number(e.returnValues.listingID))
     } else {
@@ -311,7 +312,7 @@ class V00_MarkeplaceAdapter {
     }
     const events = await this.contract.getPastEvents('OfferCreated', {
       filter,
-      fromBlock: 0
+      fromBlock: this.blockEpoch
     })
     return events.map(e => Number(e.returnValues.offerID))
   }
@@ -329,7 +330,7 @@ class V00_MarkeplaceAdapter {
     const offerTopic = this.padTopic(offerIndex)
     const events = await this.contract.getPastEvents('allEvents', {
       topics: [null, null, listingTopic, offerTopic],
-      fromBlock: 0
+      fromBlock: this.blockEpoch
     })
 
     // Scan through the events to retrieve information of interest.
@@ -390,7 +391,7 @@ class V00_MarkeplaceAdapter {
 
     const events = await this.contract.getPastEvents('allEvents', {
       topics: [null, this.padTopic(party)],
-      fromBlock: 0
+      fromBlock: this.blockEpoch
     })
 
     for (const event of events) {

--- a/src/contractInterface/users/resolver.js
+++ b/src/contractInterface/users/resolver.js
@@ -2,9 +2,9 @@ import V00_UsersAdapter from './v00_adapter'
 import UserObject from '../../models/user'
 
 class UsersResolver {
-  constructor({ contractService, ipfsService }) {
+  constructor({ contractService, ipfsService, blockEpoch }) {
     this.adapters = {
-      '000': new V00_UsersAdapter({ contractService, ipfsService })
+      '000': new V00_UsersAdapter({ contractService, ipfsService, blockEpoch })
     }
     this.versions = ['000']
     this.currentVersion = this.versions[this.versions.length - 1]

--- a/src/contractInterface/users/v00_adapter.js
+++ b/src/contractInterface/users/v00_adapter.js
@@ -13,11 +13,12 @@ const selfAttestationTopic = 13 // TODO: use the correct number here
 const emptyAddress = '0x0000000000000000000000000000000000000000'
 
 class V00_UsersAdapter {
-  constructor({ contractService, ipfsService }) {
+  constructor({ contractService, ipfsService, blockEpoch }) {
     this.contractService = contractService
     this.ipfsDataStore = new IpfsDataStore(ipfsService)
     this.web3EthAccounts = this.contractService.web3.eth.accounts
     this.contractName = 'V00_UserRegistry'
+    this.blockEpoch = blockEpoch || 0
   }
 
   async set({ profile, attestations = [], options = {}}) {
@@ -158,7 +159,7 @@ class V00_UsersAdapter {
       identityAddress
     )
     const claimAddedEvents = await identity.getPastEvents('ClaimAdded', {
-      fromBlock: 0
+      fromBlock: this.blockEpoch
     })
     const mapped = claimAddedEvents.map(({ returnValues }) => {
       return {

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,8 @@ class Origin {
     ipfsCreator,
     OrbitDB,
     ecies,
-    messagingNamespace
+    messagingNamespace,
+    blockEpoch
   } = {}) {
     this.version = VERSION
 
@@ -48,7 +49,8 @@ class Origin {
     this.attestations = new Attestations({
       serverUrl: attestationServerUrl,
       contractService: this.contractService,
-      fetch
+      fetch,
+      blockEpoch
     })
 
     this.marketplace = new Marketplace({
@@ -56,7 +58,8 @@ class Origin {
       ipfsService: this.ipfsService,
       affiliate,
       arbitrator,
-      store
+      store,
+      blockEpoch
     })
 
     this.discovery = new Discovery({
@@ -66,7 +69,8 @@ class Origin {
 
     this.users = new Users({
       contractService: this.contractService,
-      ipfsService: this.ipfsService
+      ipfsService: this.ipfsService,
+      blockEpoch
     })
 
     this.messaging = new Messaging({

--- a/src/resources/attestations.js
+++ b/src/resources/attestations.js
@@ -12,11 +12,11 @@ const responseToUrl = (resp = {}) => {
 }
 
 class Attestations {
-  constructor({ serverUrl, contractService, fetch }) {
+  constructor({ serverUrl, contractService, fetch, blockEpoch }) {
     this.serverUrl = serverUrl
     this.contractService = contractService
     this.fetch = fetch
-    this.usersResolver = new UsersResolver({ contractService })
+    this.usersResolver = new UsersResolver({ contractService, blockEpoch })
 
     this.responseToAttestation = (resp = {}) => {
       return new AttestationObject({

--- a/src/resources/users.js
+++ b/src/resources/users.js
@@ -1,11 +1,11 @@
 import UsersResolver from '../contractInterface/users/resolver'
 
 class Users {
-  constructor({ contractService, ipfsService }) {
-    this.resolver = new UsersResolver({ contractService, ipfsService })
+  constructor({ contractService, ipfsService, blockEpoch }) {
+    this.resolver = new UsersResolver({ contractService, ipfsService, blockEpoch })
   }
 
-  /* possible options values: 
+  /* possible options values:
    * - confirmationCallback(confirmationCount, transactionReceipt) -> called repeatedly after a transaction is mined
    * - transactionHashCallback(hash) -> called immediately when the transaction hash is received
    */


### PR DESCRIPTION
Stopgap for speeding up scanning of events for the marketplace contract,
particularly for Rinkeby and Mainet. Restricts getPastEvents to a recent
block number for the Marketplace contract.

Goes with OriginProtocol/origin-dapp#656 and OriginProtocol/origin-box#102

### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)
