### PR TITLE
Ignore notifications that include invalid offers

### DIFF
--- a/test/resource_marketplace.test.js
+++ b/test/resource_marketplace.test.js
@@ -369,6 +369,13 @@ describe('Marketplace Resource', function() {
       expect(notifications[0].type).to.equal('seller_review_received')
       expect(notifications[0].status).to.equal('unread')
     })
+
+    it('should exclude notifications for invalid offers', async () => {
+      await marketplace.makeOffer('999-000-0', invalidPriceOffer)
+
+      let notifications = await marketplace.getNotifications()
+      expect(notifications.length).to.equal(1)
+    })
   })
 
   describe('setNotification', () => {

--- a/test/resource_marketplace.test.js
+++ b/test/resource_marketplace.test.js
@@ -373,7 +373,7 @@ describe('Marketplace Resource', function() {
     it('should exclude notifications for invalid offers', async () => {
       await marketplace.makeOffer('999-000-0', invalidPriceOffer)
 
-      let notifications = await marketplace.getNotifications()
+      const notifications = await marketplace.getNotifications()
       expect(notifications.length).to.equal(1)
     })
   })


### PR DESCRIPTION
### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:

See linked issue below. This prevents invalid offers from causing the `getNotifications` method to crash.

Resolves https://github.com/OriginProtocol/origin-js/issues/558
