### PR TITLE
Fix overflow bug when adding more than 4 attestations

### DIFF
--- a/contracts/contracts/identity/ClaimHolderLibrary.sol
+++ b/contracts/contracts/identity/ClaimHolderLibrary.sol
@@ -76,7 +76,7 @@ library ClaimHolderLibrary {
         public
     {
         uint offset = 0;
-        for (uint8 i = 0; i < _topic.length; i++) {
+        for (uint16 i = 0; i < _topic.length; i++) {
             addClaim(
                 _keyHolderData,
                 _claims,

--- a/contracts/migrations/11_update_claim_holder_library.js
+++ b/contracts/migrations/11_update_claim_holder_library.js
@@ -1,0 +1,11 @@
+var ClaimHolderLibrary = artifacts.require("./ClaimHolderLibrary.sol")
+
+module.exports = function(deployer, network) {
+  return deployer.then(() => {
+    return deployContracts(deployer)
+  })
+}
+
+async function deployContracts(deployer) {
+  await deployer.deploy(ClaimHolderLibrary)
+}

--- a/contracts/migrations/11_update_claim_holder_library.js
+++ b/contracts/migrations/11_update_claim_holder_library.js
@@ -1,3 +1,4 @@
+// This migration is needed to update our ClaimHolderLibrary. See: https://github.com/OriginProtocol/origin-js/pull/598
 var ClaimHolderLibrary = artifacts.require("./ClaimHolderLibrary.sol")
 
 module.exports = function(deployer, network) {

--- a/test/resource_users.test.js
+++ b/test/resource_users.test.js
@@ -50,7 +50,7 @@ describe('User Resource', function() {
   let emailAttestation
   let facebookAttestation
   let twitterAttestation
-  // let airbnbAttestation
+  let airbnbAttestation
 
   beforeEach(async () => {
     const provider = new Web3.providers.HttpProvider('http://localhost:8545')
@@ -99,12 +99,12 @@ describe('User Resource', function() {
       topic: 4,
       data: 'twitter verified'
     })
-    // airbnbAttestation = await generateAttestation({
-    //   identityAddress,
-    //   web3,
-    //   topic: 5,
-    //   data: 'airbnb verified'
-    // })
+    airbnbAttestation = await generateAttestation({
+      identityAddress,
+      web3,
+      topic: 5,
+      data: 'airbnb verified'
+    })
   })
 
   describe('set', () => {
@@ -195,20 +195,20 @@ describe('User Resource', function() {
       expect(user.profile.lastName).to.equal('Widow')
     })
 
-    it('should be able to deploy new identity with 5 presigned claims', async () => {
+    it('should be able to deploy new identity with 6 presigned claims', async () => {
       await users.set({
         profile: { firstName: 'Black', lastName: 'Widow' },
         attestations: [
           phoneAttestation,
           emailAttestation,
           facebookAttestation,
-          twitterAttestation
-          // TODO support additional attestations. Currently can't handle more than 5
+          twitterAttestation,
+          airbnbAttestation
         ]
       })
       const user = await users.get()
 
-      expect(user.attestations.length).to.equal(4)
+      expect(user.attestations.length).to.equal(5)
       expect(user.profile.firstName).to.equal('Black')
       expect(user.profile.lastName).to.equal('Widow')
     })


### PR DESCRIPTION
### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:

The 5th atttestation will be at i=4 (0-indexed). 3 * 65 = 195 (no problem). 4 * 65 = 260... This is a problem because i is a uint8; 260 > 256, therefore overflow. :grimacing:

Thanks @crazybuster for figuring this out.

We do not need to rerun migrations, but we _do_ need to update origin-js with this fix, so that new identities that users create do not have this bug.

Resolves #413
