### PR TITLE
Confirmation polling on transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       "requires": {
         "@babel/types": "7.0.0-beta.44",
         "jsesc": "2.5.1",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
       },
@@ -83,7 +83,7 @@
         "@babel/code-frame": "7.0.0-beta.44",
         "@babel/types": "7.0.0-beta.44",
         "babylon": "7.0.0-beta.44",
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
       },
       "dependencies": {
         "babylon": {
@@ -109,7 +109,7 @@
         "debug": "3.1.0",
         "globals": "11.7.0",
         "invariant": "2.2.4",
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
       },
       "dependencies": {
         "babylon": {
@@ -142,7 +142,7 @@
       "dev": true,
       "requires": {
         "esutils": "2.0.2",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "to-fast-properties": "2.0.0"
       },
       "dependencies": {
@@ -914,7 +914,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "async-each": {
@@ -1004,7 +1004,7 @@
         "convert-source-map": "1.6.0",
         "fs-readdir-recursive": "1.1.0",
         "glob": "7.1.3",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "output-file-sync": "1.1.2",
         "path-is-absolute": "1.0.1",
         "slash": "1.0.0",
@@ -1062,7 +1062,7 @@
         "convert-source-map": "1.6.0",
         "debug": "2.6.9",
         "json5": "0.5.1",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "minimatch": "3.0.4",
         "path-is-absolute": "1.0.1",
         "private": "0.1.8",
@@ -1102,7 +1102,7 @@
         "babel-types": "6.26.0",
         "detect-indent": "4.0.0",
         "jsesc": "1.3.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
       }
@@ -1158,7 +1158,7 @@
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -1229,7 +1229,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -1444,7 +1444,7 @@
         "babel-template": "6.26.0",
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -1875,7 +1875,7 @@
         "babel-runtime": "6.26.0",
         "core-js": "2.5.7",
         "home-or-tmp": "2.0.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.18"
       }
@@ -1905,7 +1905,7 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "babel-traverse": {
@@ -1921,7 +1921,7 @@
         "debug": "2.6.9",
         "globals": "9.18.0",
         "invariant": "2.2.4",
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "babel-types": {
@@ -1931,7 +1931,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "to-fast-properties": "1.0.3"
       }
     },
@@ -4807,7 +4807,7 @@
         "js-yaml": "3.12.0",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
@@ -5001,7 +5001,7 @@
         "abi-decoder": "1.2.0",
         "cli-table3": "0.5.1",
         "colors": "1.3.2",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "mocha": "4.1.0",
         "req-cwd": "2.0.0",
         "request": "2.88.0",
@@ -13805,7 +13805,7 @@
       "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "growl": {
@@ -14266,7 +14266,7 @@
       "requires": {
         "html-minifier": "3.5.20",
         "loader-utils": "0.2.17",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "pretty-error": "2.1.1",
         "tapable": "1.0.0",
         "toposort": "1.0.7",
@@ -14417,7 +14417,7 @@
       "requires": {
         "http-proxy": "1.17.0",
         "is-glob": "4.0.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "micromatch": "3.1.10"
       },
       "dependencies": {
@@ -14972,7 +14972,7 @@
         "cli-width": "2.2.0",
         "external-editor": "2.2.0",
         "figures": "2.0.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
         "rx-lite": "4.0.8",
@@ -15668,7 +15668,7 @@
         "ipld": "0.15.0",
         "ipld-dag-pb": "0.13.1",
         "left-pad": "1.3.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "multihashes": "0.4.14",
         "multihashing-async": "0.4.8",
         "pull-batch": "1.0.0",
@@ -16586,7 +16586,7 @@
         "babylon": "7.0.0-beta.47",
         "colors": "1.3.2",
         "flow-parser": "0.80.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "micromatch": "2.3.11",
         "neo-async": "2.5.2",
         "node-dir": "0.1.8",
@@ -17048,7 +17048,7 @@
         "async": "2.6.1",
         "debug": "3.1.0",
         "interface-connection": "0.3.2",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "mafmt": "4.0.0",
         "multiaddr": "3.1.0",
         "multistream-select": "0.14.3",
@@ -17280,7 +17280,7 @@
       "requires": {
         "async": "2.6.1",
         "debug": "3.1.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "multiaddr": "3.1.0",
         "peer-id": "0.10.7",
         "peer-info": "0.11.6"
@@ -17706,9 +17706,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.assign": {
       "version": "4.2.0",
@@ -19816,7 +19816,7 @@
       "requires": {
         "async": "2.6.1",
         "libp2p-crypto": "0.12.1",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "multihashes": "0.4.14"
       }
     },
@@ -21655,7 +21655,7 @@
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "request-promise-native": {
@@ -23164,7 +23164,7 @@
         "commander": "2.18.0",
         "eol": "0.9.1",
         "js-string-escape": "1.0.1",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "sol-digger": "0.0.2",
         "sol-explore": "1.6.1",
         "solium-plugin-security": "0.1.1",
@@ -23888,7 +23888,7 @@
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
         "chalk": "2.4.1",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
       },
@@ -25207,7 +25207,7 @@
         "eslint-visitor-keys": "1.0.0",
         "espree": "3.5.4",
         "esquery": "1.0.1",
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
       },
       "dependencies": {
         "debug": {
@@ -26288,7 +26288,7 @@
             "babylon": "6.18.0",
             "colors": "1.3.2",
             "flow-parser": "0.80.0",
-            "lodash": "4.17.10",
+            "lodash": "4.17.11",
             "micromatch": "2.3.11",
             "node-dir": "0.1.8",
             "nomnom": "1.8.1",
@@ -26349,7 +26349,7 @@
         "jscodeshift": "0.5.1",
         "listr": "0.14.2",
         "loader-utils": "1.1.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "log-symbols": "2.2.0",
         "mkdirp": "0.5.1",
         "p-each-series": "1.0.0",
@@ -26425,7 +26425,7 @@
             "cli-width": "2.2.0",
             "external-editor": "2.2.0",
             "figures": "2.0.0",
-            "lodash": "4.17.10",
+            "lodash": "4.17.11",
             "mute-stream": "0.0.7",
             "run-async": "2.3.0",
             "rxjs": "5.5.12",
@@ -27531,7 +27531,7 @@
         "grouped-queue": "0.3.3",
         "inquirer": "6.2.0",
         "is-scoped": "1.0.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "log-symbols": "2.2.0",
         "mem-fs": "1.1.3",
         "strip-ansi": "4.0.0",
@@ -27626,7 +27626,7 @@
             "cli-width": "2.2.0",
             "external-editor": "3.0.3",
             "figures": "2.0.0",
-            "lodash": "4.17.10",
+            "lodash": "4.17.11",
             "mute-stream": "0.0.7",
             "run-async": "2.3.0",
             "rxjs": "6.3.2",
@@ -27679,7 +27679,7 @@
         "find-up": "2.1.0",
         "github-username": "4.1.0",
         "istextorbinary": "2.2.1",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "make-dir": "1.3.0",
         "mem-fs-editor": "4.0.3",
         "minimist": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "crypto-random-string": "^1.0.0",
     "ethereumjs-util": "^5.2.0",
     "form-data": "^2.3.2",
-    "lodash": "^4.17.11",
     "map-cache": "^0.2.2",
     "openzeppelin-solidity": "1.10.0",
     "rlp": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "crypto-random-string": "^1.0.0",
     "ethereumjs-util": "^5.2.0",
     "form-data": "^2.3.2",
+    "lodash": "^4.17.11",
     "map-cache": "^0.2.2",
     "openzeppelin-solidity": "1.10.0",
     "rlp": "^2.0.0",

--- a/src/services/contract-service.js
+++ b/src/services/contract-service.js
@@ -277,7 +277,7 @@ class ContractService {
       method
         .send(opts)
         .on('receipt', resolve)
-        .on('confirmation', confirmationCallback)
+        //.on('confirmation', confirmationCallback)
         //.on('transactionHash', transactionHashCallback)
         // Workaround for "confirmationCallback" not being triggered in some versions of Metamask
         .on('transactionHash', (hash) => {

--- a/src/services/contract-service.js
+++ b/src/services/contract-service.js
@@ -253,7 +253,7 @@ class ContractService {
     const bytecode = await this.getBytecode(contract)
     const deployed = await this.deployed(contract)
     const txReceipt = await new Promise((resolve, reject) => {
-      let sendCallback = deployed
+      const sendCallback = deployed
         .deploy({
           data: bytecode,
           arguments: args
@@ -296,7 +296,7 @@ class ContractService {
     // set gas
     opts.gas = (opts.gas || (await method.estimateGas(opts))) + additionalGas
     const transactionReceipt = await new Promise((resolve, reject) => {
-      let sendCallback = method
+      const sendCallback = method
         .send(opts)
 
       this.handleTransactionCallbacks(

--- a/src/services/contract-service.js
+++ b/src/services/contract-service.js
@@ -220,7 +220,7 @@ class ContractService {
       promiseStatus.numberOfTimesTransactionFoundByFallbackFcnt += 1
 
       /* If fallback function detects a valid transaction for the second time and the main function has
-       * not registered a transaction recite, positively resolve the promise with generated recite. This resolves
+       * not registered a transaction receipt, positively resolve the promise with generated receipt. This resolves
        * problems created by Metamask 4.12.0.
        */
       if (!promiseStatus.receiptReceived && promiseStatus.numberOfTimesTransactionFoundByFallbackFcnt > 1){

--- a/src/services/contract-service.js
+++ b/src/services/contract-service.js
@@ -13,7 +13,8 @@ import bs58 from 'bs58'
 import Web3 from 'web3'
 
 const emptyAddress = '0x0000000000000000000000000000000000000000'
-const NUMBER_CONFIRMATIONS_TO_REPORT = 20
+//24 is the number web3 supplies
+const NUMBER_CONFIRMATIONS_TO_REPORT = 24
 const SUPPORTED_ERC20 = [
   { symbol: 'OGN', decimals: 18, contractName: 'OriginToken' }
 ]

--- a/src/services/contract-service.js
+++ b/src/services/contract-service.js
@@ -241,7 +241,7 @@ class ContractService {
            * Just conform to that format
            */
           return _.mapValues(_.groupBy(events, 'event'),
-            eventList => eventList.length == 1 ? eventList[0] : eventList)
+            eventList => eventList.length === 1 ? eventList[0] : eventList)
         }
 
 

--- a/src/services/contract-service.js
+++ b/src/services/contract-service.js
@@ -11,7 +11,7 @@ import V00_Marketplace from './../../contracts/build/contracts/V00_Marketplace.j
 import BigNumber from 'bignumber.js'
 import bs58 from 'bs58'
 import Web3 from 'web3'
-import _ from 'lodash'
+import { groupBy, mapValues } from './../utils/arrayFunctions'
 
 const emptyAddress = '0x0000000000000000000000000000000000000000'
 // 24 is the number web3 supplies
@@ -240,7 +240,7 @@ class ContractService {
            * If more than 1 event of the same name is returned it is an array, otherwise an object.
            * Just conform to that format
            */
-          return _.mapValues(_.groupBy(events, 'event'),
+          return mapValues(groupBy(events, (event) => event.event),
             eventList => eventList.length === 1 ? eventList[0] : eventList)
         }
 

--- a/src/services/contract-service.js
+++ b/src/services/contract-service.js
@@ -229,7 +229,7 @@ class ContractService {
     const transactionInfo = await this.web3.eth.getTransaction(hash)
 
     // transaction not mined
-    if (transactionInfo.blockNumber === null){
+    if (transactionInfo === null || transactionInfo.blockNumber === null){
       setTimeout(() => {
         this.checkForDeploymentCompletion(hash, confirmationCallback)
       }, 1500)

--- a/src/services/contract-service.js
+++ b/src/services/contract-service.js
@@ -220,7 +220,7 @@ class ContractService {
       confirmationCallback(confirmations, {
         transactionHash: transactionInfo.hash
       })
-      
+
       if (confirmations < NUMBER_CONFIRMATIONS_TO_REPORT) {
         setTimeout(() => {
           this.checkForTransactionCompletion(hash, confirmationCallback, transactionStatus)
@@ -229,8 +229,9 @@ class ContractService {
     }
   }
 
-  // Unify the way contract's send methods calls are handled
+  // Unify the way contract's transactions/deployments are handled
   handleTransactionCallbacks(sendCallback, resolveCallback, rejectCallback, confirmationCallback, transactionHashCallback) {
+    // needs to be an object because it is passed to functions by reference
     const transactionStatus = { onConfirmationTriggered: false }
     sendCallback
       .on('receipt', resolveCallback)

--- a/src/utils/arrayFunctions.js
+++ b/src/utils/arrayFunctions.js
@@ -8,11 +8,11 @@
  */
 function groupBy(collection, iteratee){
   return collection.reduce(function (accumulator, element) {
-      let key = iteratee(element)
-      accumulator[key] = accumulator[key] || [];
-      accumulator[key].push(element);
-      return accumulator;
-  }, Object.create(null));
+    const key = iteratee(element)
+    accumulator[key] = accumulator[key] || []
+    accumulator[key].push(element)
+    return accumulator
+  }, Object.create(null))
 }
 
 /**

--- a/src/utils/arrayFunctions.js
+++ b/src/utils/arrayFunctions.js
@@ -1,0 +1,32 @@
+/**
+ * Creates an object composed of keys generated from the results of running
+ * each element of `collection` thru `iteratee`. 
+ * 
+ * @param  {Array} collection The collection to iterate over.
+ * @param  {Function} iteratee The iteratee to transform keys.
+ * @return {Object} Returns the composed aggregate object.
+ */
+function groupBy(collection, iteratee){
+  return collection.reduce(function (accumulator, element) {
+      let key = iteratee(element)
+      accumulator[key] = accumulator[key] || [];
+      accumulator[key].push(element);
+      return accumulator;
+  }, Object.create(null));
+}
+
+/**
+ * Applies transformation function to values of an object while preserving keys 
+ * 
+ * @param  {Object} object to iterate over
+ * @param  {Function} mapFunction The functino that transforms the value
+ * @return {Object} Returns the transformed object
+ */
+function mapValues(object, mapFunction){
+  return Object.assign(
+    ...Object.keys(object)
+      .map(k => ({[k]: mapFunction(object[k])}))
+  )
+}
+
+module.exports = { groupBy, mapValues }


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [ ] Ensure all new and existing tests pass
- ~[ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)~

**TODO:**
- in case we decide to merge this, tests still need to be written

### Description:
Metamask 4.12.0 introduced some breaking changes where `confirmation` and `receipt` events are not always triggered. And sometimes an error is thrown in spite of blockchain transaction succeeding. 

The solution this PR proposes: 
- for easier handling refactor so that contract function calls and contract deploys are handled by the same function
- keep `confirmation` and `receipt` events present and stop fallback solution in case those events are triggered
- when submitting transaction start a fallback pooling function that: 
  - continually pools for transaction receipt. If it finds it and `confirmation` event has not been triggered. Manually call confirmation callback
  - if transaction receipt has not been returned as promise resolution, mock it and resolve promise with it. 
- when we receive an error from Metamask that we know is not breaking don't reject the promise. Let fallback function handle resolution. 

**Related issues:**
- https://github.com/OriginProtocol/origin-dapp/issues/639
- https://github.com/OriginProtocol/origin-dapp/issues/673

